### PR TITLE
Added Remove Job script, fixed issue with not returing jobId if job already exsists

### DIFF
--- a/Public/Add-DatabricksNotebookJob.ps1
+++ b/Public/Add-DatabricksNotebookJob.ps1
@@ -98,7 +98,7 @@ Extended: Simon D'Morias / Data Thirst Ltd
 
     if ($ExistingJobDetail){
         $JobId = $ExistingJobDetail.job_id[0]
-        Write-Output "Updating JobId: $JobId"
+        Write-Verbose "Updating JobId: $JobId"
         $Mode = "reset"
     } 
     else{
@@ -166,7 +166,7 @@ Extended: Simon D'Morias / Data Thirst Ltd
         Write-Error $_.ErrorDetails.Message
     }
 
-    if ($Moode -eq "create") {
+    if ($Mode -eq "create") {
         Return $JobDetails.job_id
     }
     else {

--- a/Public/Remove-DatabricksJob.ps1
+++ b/Public/Remove-DatabricksJob.ps1
@@ -1,0 +1,48 @@
+Function Remove-DatabricksJob
+{ 
+    [cmdletbinding()]
+    param (
+        [parameter(Mandatory = $true)][string]$BearerToken, 
+        [parameter(Mandatory = $true)][string]$Region,
+        [parameter(Mandatory = $false)][string]$JobId
+    ) 
+<#
+.SYNOPSIS
+Delete a job from Databricks with given Job Id
+
+.DESCRIPTION
+Delete a job from Databricks with given Job Id 
+
+.PARAMETER BearerToken
+Your Databricks Bearer token to authenticate to your workspace (see User Settings in Datatbricks WebUI)
+
+.PARAMETER Region
+Azure Region - must match the URL of your Databricks workspace, example northeurope
+
+.PARAMETER JobId
+Id of the job to delete
+
+.NOTES
+Author: Tadeusz Balcer
+#>  
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $InternalBearerToken =  Format-BearerToken($BearerToken) 
+    $Region = $Region.Replace(" ","")
+    
+    $Body = @{}
+    $Body['job_id'] = $JobId
+
+    $BodyText = $Body | ConvertTo-Json -Depth 10
+    
+    Try {
+        Invoke-RestMethod -Method Post -Body $BodyText -Uri "https://$Region.azuredatabricks.net/api/2.0/jobs/delete" -Headers @{Authorization = $InternalBearerToken}
+    }
+    Catch {
+        Write-Output "StatusCode:" $_.Exception.Response.StatusCode.value__ 
+        Write-Output "StatusDescription:" $_.Exception.Response.StatusDescription
+        Write-Error $_.ErrorDetails.Message
+    }
+
+    Return 
+}
+    

--- a/Tests/Add-DatabricksNotebookJob.tests.ps1
+++ b/Tests/Add-DatabricksNotebookJob.tests.ps1
@@ -1,3 +1,7 @@
+param(
+    [bool] $removeCreatedJob = $true
+)
+
 Import-Module "$PSScriptRoot\..\azure.databricks.cicd.tools.psm1" -Force
 $BearerToken = Get-Content "$PSScriptRoot\MyBearerToken.txt"  # Create this file in the Tests folder with just your bearer token in
 
@@ -27,7 +31,6 @@ Describe "Add-DatabricksNotebookJob" {
             -NotebookParametersJson $NotebookParametersJson `
             -Libraries $Libraries
 
-        Write-Host $JobId
         $JobId | Should -BeGreaterThan 0
     }
 
@@ -40,7 +43,8 @@ Describe "Add-DatabricksNotebookJob" {
             -Libraries $Libraries
 
         $JobId | Should -BeGreaterThan 0
+        if($removeCreatedJob) {
+            Remove-DatabricksJob -BearerToken $BearerToken -Region $Region -JobId $JobId
+        }
     }
 }
-
-


### PR DESCRIPTION
Hi!

After your changes code in Add-DatabricksNotebookJob looks great, I really love it. 
I found a minor issue - if Job already exists in Databricks, it doesn't return JobId (because of typo and Write-Output in script).
Write-Output caused returning array with jobId and WriteOutput value after running script instead of only jobId.

Please take a look on it and merge if you think it's fine.

Thanks.