### PR TITLE
No need to pass Bearer token

### DIFF
--- a/Public/New-DatabricksCluster.ps1
+++ b/Public/New-DatabricksCluster.ps1
@@ -100,7 +100,7 @@ Function New-DatabricksCluster {
     $ClusterArgs = @{}
     If ($UniqueNames)
     {
-        $ClusterId = (Get-DatabricksClusters -Bearer $BearerToken -Region $Region | Where-Object {$_.cluster_name -eq $ClusterName})
+        $ClusterId = (Get-DatabricksClusters | Where-Object {$_.cluster_name -eq $ClusterName})
         if ($ClusterId){
             if ($Update){
                 $Mode = "edit"


### PR DESCRIPTION
Bug when using new authentication method as Bearer token does not exist. Use global connection method instead.