### PR TITLE
Tempnewitemforce

### DIFF
--- a/Private/Set-LocalNotebook.ps1
+++ b/Private/Set-LocalNotebook.ps1
@@ -30,7 +30,7 @@ function Set-LocalNotebook ($DatabricksFile, $Language, $LocalOutputPath, $Forma
         # Databricks exports with a comment line in the header, remove this and ensure we have Windows line endings
         Invoke-RestMethod -Method Get -Uri $uri -Headers $Headers -OutFile $tempLocalExportPath
         $Response = Get-Content $tempLocalExportPath -Encoding UTF8
-        $Response = $response | Select-Object -Skip 1
+        $Response = $response.Replace("# Databricks notebook source", " ")
         Remove-Item $tempLocalExportPath
         if ($Format -eq "SOURCE"){
             $Response = ($Response.replace("[^`r]`n", "`r`n") -Join "`r`n")

--- a/Private/Set-LocalNotebook.ps1
+++ b/Private/Set-LocalNotebook.ps1
@@ -22,6 +22,7 @@ function Set-LocalNotebook ($DatabricksFile, $Language, $LocalOutputPath, $Forma
     $tempLocalExportPath = $DatabricksFile.Replace($ExportPath + "/", "") + ".temp" + $FileExt
     $LocalExportPath = Join-Path $LocalOutputPath $LocalExportPath
     $tempLocalExportPath = Join-Path $LocalOutputPath $tempLocalExportPath
+    New-Item -Force -path $tempLocalExportPath -Type File | Out-Null
     $Headers = GetHeaders $null
     
     Try


### PR DESCRIPTION
PR to resolve broken tests mentioned at end of #91 

First commit forces new folders to be created where they do not exist for the temp files.

Second commit is possible fix for where a notebook is empty, like the test ones, and removing the comment results in the $response being set to $null by
         
```$Response = $response | Select-Object -Skip 1```

There's probable alternatives; happy for feedback!