### PR TITLE
Added URL Encoding for aad client secret

### DIFF
--- a/Private/ConnectFunctions.ps1
+++ b/Private/ConnectFunctions.ps1
@@ -50,6 +50,7 @@ Function Get-AADDatabricksToken{
         }
         "Missing" {
             Write-Verbose "Getting new AAD Databricks Token"
+            $Secret = [System.Web.HttpUtility]::UrlEncode($Secret)
             $BodyText="grant_type=client_credentials&client_id=$ApplicationId&resource=2ff814a6-3304-4ab8-85cb-cd0e6f879c1d&client_secret=$Secret"
             $Response = Invoke-RestMethod -Method POST -Body $BodyText -Uri $URI -ContentType application/x-www-form-urlencoded
         }


### PR DESCRIPTION
Added URL Encoding for secret when requesting AAD token. This is important in case of certain special characters in the client secret

Per MS documentation:
![image](https://user-images.githubusercontent.com/18422663/69877381-578c7680-12c2-11ea-9404-ce54ed7bf5aa.png)

(from this [site](https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-oauth2-client-creds-grant-flow) )
