### PR TITLE
Added PrincipalType to the acl, to include group and sp.

### DIFF
--- a/Public/Set-DatabricksPermission.ps1
+++ b/Public/Set-DatabricksPermission.ps1
@@ -13,7 +13,12 @@
     Azure Region - must match the URL of your Databricks workspace, example northeurope
 
 .PARAMETER Principal
-    "user_name"​​ || ​"group_name"​ ​|| "service_principal_name"
+    The name of the "user","group","service_principal" that will be added to the object.
+    
+.PARAMETER PrincipalType
+  Which type of pricipal do you want to add to the object.
+  Valid values for this parameter are: 
+  "user_name"​​ || ​"group_name"​ ​|| "service_principal_name"
 
 .PARAMETER PermissionLevel
     See Get-DatabricksPermissionLevels
@@ -42,6 +47,7 @@ Function Set-DatabricksPermission
         [parameter(Mandatory=$false)][string]$BearerToken,
         [parameter(Mandatory=$false)][string]$Region,
         [parameter(Mandatory=$true)][string]$Principal,
+        [parameter(Mandatory=$true)][ValidateSet('user_name','group_name','service_principal_name')][string]$PrincipalType,
         [Parameter(Mandatory=$true)][string]$PermissionLevel,
         [Parameter(Mandatory=$true)][ValidateSet('job','cluster','instance-pool', 'secretScope')][string]$DatabricksObjectType,
         [Parameter(Mandatory=$true)][string]$DatabricksObjectId
@@ -73,7 +79,14 @@ Function Set-DatabricksPermission
         $BasePath = "$global:DatabricksURI/api/2.0/preview"
         $URI =  "$BasePath/permissions/$DatabricksObjectType" + "s/$DatabricksObjectId"
     
-        $acl = @(@{"user_name"= $Principal; "permission_level"=$PermissionLevel})
+    
+        switch ($PrincipalType) 
+        { 
+            "user_name" {$acl = @(@{"user_name"= $Principal; "permission_level"=$PermissionLevel})} 
+            "group_name" {$acl = @(@{"group_name"= $Principal; "permission_level"=$PermissionLevel})} 
+            "service_principal_name" {$acl = @(@{"service_principal_name"= $Principal; "permission_level"=$PermissionLevel})} 
+        }
+        
         $Body = @{"access_control_list"= $acl} | ConvertTo-Json -Depth 10
 
         Write-Verbose $Body
@@ -82,5 +95,4 @@ Function Set-DatabricksPermission
     
     return $Response
 }
-
 


### PR DESCRIPTION
If I wanted to add a databricks group to the object this fails because apparently only user_name was added to the acl.
Made an extra parameter "PrincipalType" that will provide which type you need to add to the object and the acl in the body will be set correctly when you want to add something else than a group.