### PR TITLE
Threaded Import-DataBricksFolder

### DIFF
--- a/azure.databricks.cicd.tools.psd1
+++ b/azure.databricks.cicd.tools.psd1
@@ -30,7 +30,7 @@
     Description = 'PowerShell module to help with Azure Databricks CI & CD Scenarios by simplifying the API or CLI calls into idempotent commands. See https://github.com/DataThirstLtd/azure.databricks.cicd.tools & https://datathirst.net'
 
     # Minimum version of the Windows PowerShell engine required by this module
-    PowerShellVersion = '5.0'
+    PowerShellVersion = '5.1'
 
     # Name of the Windows PowerShell host required by this module
     # PowerShellHostName = ''
@@ -48,7 +48,9 @@
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    # RequiredModules = @()
+    #RequiredModules =  @(
+    #    @{ModuleName="ThreadJob";ModuleVersion="2.0.3";Guid="0e7b895d-2fec-43f7-8cae-11e8d16f6e40"}
+    #)
 
     # Assemblies that must be loaded prior to importing this module
     # RequiredAssemblies = @('')

--- a/azure.databricks.cicd.tools.psm1
+++ b/azure.databricks.cicd.tools.psm1
@@ -1,16 +1,13 @@
 #Get public and private function definition files.
-$Public  = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue )
+$Public = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue )
 $Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue )
 
 #Dot source the files
-Foreach($import in @($Public + $Private))
-{
-    Try
-    {
+Foreach ($import in @($Public + $Private)) {
+    Try {
         . $import.fullname
     }
-    Catch
-    {
+    Catch {
         Write-Error -Message "Failed to import function $($import.fullname): $_"
     }
 }
@@ -18,3 +15,14 @@ Foreach($import in @($Public + $Private))
 # Export Public functions
 Export-ModuleMember -Function $Public.Basename
 Export-ModuleMember -Alias * -Function *
+
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    $checkThreadJob = Get-InstalledModule -Name "ThreadJob" -MinimumVersion "2.0.3" -ErrorAction SilentlyContinue
+    if ($null -eq $checkThreadJob) {
+        Install-Module -Name ThreadJob -RequiredVersion 2.0.3 -Force -Scope CurrentUser
+    }
+    $checkThreadJob = Get-InstalledModule -Name "ThreadJob" -MinimumVersion "2.0.3" -ErrorAction SilentlyContinue
+    if($null -eq $checkThreadJob){
+        Write-Error "oh dear thread job not installed"
+    }
+}


### PR DESCRIPTION
Added threading to Import-Databricks folder using Start-ThreadJob. As Start-ThreadJob is only available from 6.1 and above, have added a check in the psd1 file to install ThreadJob 2.0.3 from PowerShell gallery, which supports version 5.1, if the version is less than 6.1. This means I have also had to bump up the PowerShellVersion to 5.1 in the psm1 file.

I have set the limit of the number of threadjobs to be twice the number of cores on the machine running the module; this could be set higher but it's a safe limit and the import now takes about a quarter of what it used to for our projects.
