### PR TITLE
Update Get-DatabricksDBFSFile.ps1

### DIFF
--- a/Public/Get-DatabricksDBFSFile.ps1
+++ b/Public/Get-DatabricksDBFSFile.ps1
@@ -24,7 +24,7 @@ PS C:\> Get-DatabricksDBFSFile -BearerToken $BearerToken -Region $Region -DBFSFi
 Author: Simon D'Morias / Data Thirst Ltd 
 #>  
 
-Function Get-DatabricksDBFSFiles {
+Function Get-DatabricksDBFSFile {
     param(
         [parameter(Mandatory = $false)][string]$BearerToken,
         [parameter(Mandatory = $false)][string]$Region,


### PR DESCRIPTION
I can't see exactly why you added the PS version required to 6 or higher. But this provided with some errors inside PS version 5.1. 
reference:  https://github.com/PowerShell/PowerShell/issues/3131
Because I run this script inside Azure DevOps pipelines (which has no possibility to use PS 6 or higher).
I changed the script to handle the commands and rest call to capture the file even with PS 5.1.
If you find another way around this no problem, just pointing out the problem and where the workaround should be handled.
*Also remember your scripts are being used by people in automated flaws, changing them will have some impact.