### PR TITLE
Create and edit respond differently

### DIFF
--- a/Public/New-DatabricksCluster.ps1
+++ b/Public/New-DatabricksCluster.ps1
@@ -135,11 +135,18 @@ Function New-DatabricksCluster {
     $BodyText = Remove-DummyKey $BodyText
     Write-Verbose $BodyText
     Try {
-        Invoke-RestMethod -Method Post -Body $BodyText -Uri "$global:DatabricksURI/api/2.0/clusters/$Mode" -Headers $Headers
+        if ($Mode -eq "create"){
+            $ClusterId = Invoke-RestMethod -Method Post -Body $BodyText -Uri "$global:DatabricksURI/api/2.0/clusters/create" -Headers $Headers
+        }
+        if ($Mode -eq "edit"){
+            Invoke-RestMethod -Method Post -Body $BodyText -Uri "$global:DatabricksURI/api/2.0/clusters/edit" -Headers $Headers
+        }
     }
     Catch {
         Write-Output "StatusCode:" $_.Exception.Response.StatusCode.value__ 
         Write-Output "StatusDescription:" $_.Exception.Response.StatusDescription
         Write-Error $_.ErrorDetails.Message
     }
+
+    return $ClusterId.cluster_id
 }

--- a/Tests/New-DataBricksCluster.tests.ps1
+++ b/Tests/New-DataBricksCluster.tests.ps1
@@ -35,7 +35,7 @@ Describe "New-DatabricksCluster" {
             -Spark_conf $Spark_conf -CustomTags $CustomTags -AutoTerminationMinutes $AutoTerminationMinutes -ClusterLogPath $ClusterLogPath `
             -Verbose -SparkEnvVars $SparkEnvVars -PythonVersion $PythonVersion -InitScripts $InitScripts    # -UniqueNames -Update 
 
-        $ClusterId.cluster_id.Length | Should -BeGreaterThan 1
+        $ClusterId.Length | Should -BeGreaterThan 1
     }
 
     AfterAll {


### PR DESCRIPTION
Edit does not return the cluster id so use the value from the initial get.
Create obviously does so use the returned value.