### PR TITLE
Import/Export Job Updates

### DIFF
--- a/Public/Add-DatabricksNotebookJob.ps1
+++ b/Public/Add-DatabricksNotebookJob.ps1
@@ -122,7 +122,7 @@ Function Add-DatabricksNotebookJob {
         [parameter(Mandatory = $false)][string]$BearerToken,    
         [parameter(Mandatory = $false)][string]$Region,
         [parameter(Mandatory = $true)][string]$JobName,
-        [parameter(Mandatory = $false)]$JobSettings,
+        [parameter(ValueFromPipeline, Mandatory = $false)][object]$InputObject,
         [parameter(Mandatory = $false)][string]$ClusterId,
         [parameter(Mandatory = $false)][string]$SparkVersion,
         [parameter(Mandatory = $false)][string]$NodeType,
@@ -166,7 +166,7 @@ Function Add-DatabricksNotebookJob {
         $Mode = "create"
     }
  
-    if ($PSBoundParameters.ContainsKey('jobSettings') -eq $false) {
+    if ($PSBoundParameters.ContainsKey('InputObject') -eq $false) {
         $JobBody = @{ }   
         if ($RunImmediate.IsPresent) {
             $JobBody['run_name'] = $JobName
@@ -246,7 +246,7 @@ Function Add-DatabricksNotebookJob {
         }
     }
     else {
-        $jobBody = $jobSettings
+        $jobBody = $InputObject
     }
 
     If ($Mode -eq 'create') {

--- a/Public/Add-DatabricksNotebookJob.ps1
+++ b/Public/Add-DatabricksNotebookJob.ps1
@@ -117,11 +117,12 @@ Extended: Simon D'Morias / Data Thirst Ltd
 #>
 
 Function Add-DatabricksNotebookJob {  
-   [cmdletbinding()]
+    [cmdletbinding()]
     param (
         [parameter(Mandatory = $false)][string]$BearerToken,    
         [parameter(Mandatory = $false)][string]$Region,
         [parameter(Mandatory = $true)][string]$JobName,
+        [parameter(Mandatory = $false)]$JobSettings,
         [parameter(Mandatory = $false)][string]$ClusterId,
         [parameter(Mandatory = $false)][string]$SparkVersion,
         [parameter(Mandatory = $false)][string]$NodeType,
@@ -131,15 +132,15 @@ Function Add-DatabricksNotebookJob {
         [parameter(Mandatory = $false)][int]$Timeout,
         [parameter(Mandatory = $false)][string]$EmailAlertsOnFailure,
         [parameter(Mandatory = $false)][string]$EmailAlertsOnStart,
-         [parameter(Mandatory = $false)][string]$EmailAlertsOnSuccess,
+        [parameter(Mandatory = $false)][string]$EmailAlertsOnSuccess,
         [parameter(Mandatory = $false)][switch]$noAlertSkippedRuns,
         [parameter(Mandatory = $false)][int]$MaxRetries,
         [parameter(Mandatory = $false)][string]$ScheduleCronExpression,
         [parameter(Mandatory = $false)][string]$Timezone,
-        [parameter(Mandatory = $true)][string]$NotebookPath,
+        [parameter(Mandatory = $false)][string]$NotebookPath,
         [parameter(Mandatory = $false)][string]$NotebookParametersJson,
         [parameter(Mandatory = $false)][string[]]$Libraries,
-        [parameter(Mandatory = $false)][ValidateSet(2,3)] [string]$PythonVersion=3,
+        [parameter(Mandatory = $false)][ValidateSet(2, 3)] [string]$PythonVersion = 3,
         [parameter(Mandatory = $false)][hashtable]$Spark_conf,
         [parameter(Mandatory = $false)][hashtable]$CustomTags,
         [parameter(Mandatory = $false)][string[]]$InitScripts,
@@ -151,105 +152,109 @@ Function Add-DatabricksNotebookJob {
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $Headers = GetHeaders $PSBoundParameters
-    
 
     $ExistingJobs = Get-DatabricksJobs -BearerToken $BearerToken -Region $Region
 
-    $ExistingJobDetail = $ExistingJobs | Where-Object {$_.settings.name -eq $JobName} | Select-Object job_id -First 1
+    $ExistingJobDetail = $ExistingJobs | Where-Object { $_.settings.name -eq $JobName } | Select-Object job_id -First 1
 
-    if (($ExistingJobDetail) -and (!($RunImmediate.IsPresent))){
+    if (($ExistingJobDetail) -and (!($RunImmediate.IsPresent))) {
         $JobId = $ExistingJobDetail.job_id[0]
         Write-Verbose "Updating JobId: $JobId"
         $Mode = "reset"
     } 
-    else{
+    else {
         $Mode = "create"
     }
+ 
+    if ($PSBoundParameters.ContainsKey('jobSettings') -eq $false) {
+        $JobBody = @{ }   
+        if ($RunImmediate.IsPresent) {
+            $JobBody['run_name'] = $JobName
+        }
+        else {
+            $JobBody['name'] = $JobName
+        }
 
-    $JobBody = @{}
-    if ($RunImmediate.IsPresent){
-        $JobBody['run_name'] = $JobName
-    }
-    else{
-        $JobBody['name'] = $JobName
-    }
+        If ($ClusterId) {
+            $JobBody['existing_cluster_id'] = $ClusterId
+        }
+        else {
+            $ClusterArgs = @{ }
+            $ClusterArgs['SparkVersion'] = $SparkVersion
+            $ClusterArgs['NodeType'] = $NodeType
+            $ClusterArgs['MinNumberOfWorkers'] = $MinNumberOfWorkers
+            $ClusterArgs['MaxNumberOfWorkers'] = $MaxNumberOfWorkers
+            $ClusterArgs['DriverNodeType'] = $DriverNodeType
+            $ClusterArgs['Spark_conf'] = $Spark_conf
+            $ClusterArgs['CustomTags'] = $CustomTags
+            $ClusterArgs['InitScripts'] = $InitScripts
+            $ClusterArgs['SparkEnvVars'] = $SparkEnvVars
+            $ClusterArgs['PythonVersion'] = $PythonVersion
+            $ClusterArgs['ClusterLogPath'] = $ClusterLogPath
+            $ClusterArgs['InstancePoolId'] = $InstancePoolId
 
-    If ($ClusterId){
-        $JobBody['existing_cluster_id'] = $ClusterId
+            $JobBody['new_cluster'] = (GetNewClusterCluster @ClusterArgs)
+        }
+
+        If ($PSBoundParameters.ContainsKey('Timeout')) { $JobBody['timeout_seconds'] = $Timeout }
+        If ($PSBoundParameters.ContainsKey('MaxRetries')) { $JobBody['max_retries'] = $MaxRetries }
+        If ($PSBoundParameters.ContainsKey('ScheduleCronExpression')) {
+            $JobBody['schedule'] = @{"quartz_cron_expression" = $ScheduleCronExpression; "timezone_id" = $Timezone }
+        }
+
+
+        If ($PSBoundParameters.ContainsKey('EmailAlertsOnStart')) {
+            $JobBody['email_notifications'] = @{"on_start" = $EmailAlertsOnStart }
+        }
+
+        If ($PSBoundParameters.ContainsKey('EmailAlertsOnSuccess')) {
+            If ($PSBoundParameters.ContainsKey('EmailAlertsOnStart')) {
+                $JobBody['email_notifications'].Add("on_success", $EmailAlertsOnSuccess)
+            }
+            else {
+                $JobBody['email_notifications'] = @{"on_success" = $EmailAlertsOnSuccess }
+            }
+        }
+
+        If ($PSBoundParameters.ContainsKey('EmailAlertsOnFailure')) {
+            If ($PSBoundParameters.ContainsKey('EmailAlertsOnSuccess') -or $PSBoundParameters.ContainsKey('EmailAlertsOnStart')) {
+                $JobBody['email_notifications'].Add("on_failure", $EmailAlertsOnFailure)
+            }
+            else {
+                $JobBody['email_notifications'] = @{"on_failure" = $EmailAlertsOnFailure }
+            }
+    
+        }
+
+        if ($noAlertSkippedRuns.IsPresent) {
+            $JobBody['email_notifications'].Add("no_alert_for_skipped_runs", $true)
+        }
+
+        $Notebook = @{ }
+        $Notebook['notebook_path'] = $NotebookPath
+        If ($PSBoundParameters.ContainsKey('NotebookParametersJson')) {
+            $Notebook['base_parameters'] = $NotebookParametersJson | ConvertFrom-Json
+        }
+
+        $JobBody['notebook_task'] = $Notebook
+
+        If ($PSBoundParameters.ContainsKey('Libraries')) {
+            If ($Libraries.Count -eq 1) {
+                $Libraries += '{"DummyKey":"1"}'
+            }
+            $JobBody['libraries'] = $Libraries | ConvertFrom-Json
+        }
     }
     else {
-        $ClusterArgs = @{}
-        $ClusterArgs['SparkVersion'] = $SparkVersion
-        $ClusterArgs['NodeType'] = $NodeType
-        $ClusterArgs['MinNumberOfWorkers'] = $MinNumberOfWorkers
-        $ClusterArgs['MaxNumberOfWorkers'] = $MaxNumberOfWorkers
-        $ClusterArgs['DriverNodeType'] = $DriverNodeType
-        $ClusterArgs['Spark_conf'] = $Spark_conf
-        $ClusterArgs['CustomTags'] = $CustomTags
-        $ClusterArgs['InitScripts'] = $InitScripts
-        $ClusterArgs['SparkEnvVars'] = $SparkEnvVars
-        $ClusterArgs['PythonVersion'] = $PythonVersion
-        $ClusterArgs['ClusterLogPath'] = $ClusterLogPath
-        $ClusterArgs['InstancePoolId'] = $InstancePoolId
-
-        $JobBody['new_cluster'] = (GetNewClusterCluster @ClusterArgs)
+        $jobBody = $jobSettings
     }
 
-    If ($PSBoundParameters.ContainsKey('Timeout')) {$JobBody['timeout_seconds'] = $Timeout}
-    If ($PSBoundParameters.ContainsKey('MaxRetries')) {$JobBody['max_retries'] = $MaxRetries}
-    If ($PSBoundParameters.ContainsKey('ScheduleCronExpression')) {
-        $JobBody['schedule'] = @{"quartz_cron_expression"=$ScheduleCronExpression;"timezone_id"=$Timezone}
-    }
-
-
-    If ($PSBoundParameters.ContainsKey('EmailAlertsOnStart')) {
-        $JobBody['email_notifications'] = @{"on_start"= $EmailAlertsOnStart}
-    }
-
-    If ($PSBoundParameters.ContainsKey('EmailAlertsOnSuccess')) {
-        If ($PSBoundParameters.ContainsKey('EmailAlertsOnStart')) {
-            $JobBody['email_notifications'].Add("on_success",$EmailAlertsOnSuccess)
-        }
-        else{
-            $JobBody['email_notifications'] = @{"on_success"= $EmailAlertsOnSuccess}
-        }
-    }
-
-    If ($PSBoundParameters.ContainsKey('EmailAlertsOnFailure')) {
-        If ($PSBoundParameters.ContainsKey('EmailAlertsOnSuccess') -or $PSBoundParameters.ContainsKey('EmailAlertsOnStart')) {
-            $JobBody['email_notifications'].Add("on_failure",$EmailAlertsOnFailure)
-        }
-        else{
-            $JobBody['email_notifications'] = @{"on_failure"= $EmailAlertsOnFailure}
-        }
-    
-    }
-
-    if ($noAlertSkippedRuns.IsPresent){
-          $JobBody['email_notifications'].Add("no_alert_for_skipped_runs",$true)
-    }
-
-    $Notebook = @{}
-    $Notebook['notebook_path'] = $NotebookPath
-    If ($PSBoundParameters.ContainsKey('NotebookParametersJson')) {
-        $Notebook['base_parameters'] = $NotebookParametersJson | ConvertFrom-Json
-    }
-
-    $JobBody['notebook_task'] = $Notebook
-
-    If ($PSBoundParameters.ContainsKey('Libraries')) {
-        If ($Libraries.Count -eq 1) {
-            $Libraries += '{"DummyKey":"1"}'
-        }
-        $JobBody['libraries'] = $Libraries | ConvertFrom-Json
-    }
-
-    If ($Mode -eq 'create'){
+    If ($Mode -eq 'create') {
         $Body = $JobBody
     }
     else {
-        $Body = @{}
-        $Body['job_id']= $JobId
+        $Body = @{ }
+        $Body['job_id'] = $JobId
         $Body['new_settings'] = $JobBody
     }
 
@@ -259,10 +264,10 @@ Function Add-DatabricksNotebookJob {
     Write-Verbose $BodyText
   
     Try {
-        if ($RunImmediate.IsPresent){
+        if ($RunImmediate.IsPresent) {
             $Url = "jobs/runs/submit"
         }
-        else{
+        else {
             $Url = "jobs/$Mode"
         }   
         $JobDetails = Invoke-RestMethod -Method Post -Body $BodyText -Uri "$global:DatabricksURI/api/2.0/$Url" -Headers $Headers
@@ -273,10 +278,10 @@ Function Add-DatabricksNotebookJob {
         Write-Error $_.ErrorDetails.Message
     }
     
-    if ($RunImmediate.IsPresent){
+    if ($RunImmediate.IsPresent) {
         Return $JobDetails.run_id
     }
-    else{
+    else {
         if ($Mode -eq "create") {
             Return $JobDetails.job_id
         }

--- a/Public/Export-DatabricksJobs.ps1
+++ b/Public/Export-DatabricksJobs.ps1
@@ -1,0 +1,54 @@
+<#
+.SYNOPSIS
+Exports DataBricks Jobs and Saves as json.
+
+.DESCRIPTION
+Exports Databricks Jobs and saves as json. Use '-settingsonly' in order for them to be published via Add-DatabricksNotebookJob and using $jobSettings
+
+.PARAMETER BearerToken
+Your Databricks Bearer token to authenticate to your workspace (see User Settings in Datatbricks WebUI)
+
+.PARAMETER Region
+Azure Region - must match the URL of your Databricks workspace, example northeurope
+
+.PARAMETER JobIds
+Array of job IDs that you want to export
+
+.PARAMETER SettingsOnly
+Will save only the settings of the job that are required to create the job via the API.
+
+.PARAMETER LocalOutputPath
+Local directroy to save json files.
+
+.EXAMPLE
+
+.NOTES
+Author: Simon D'Morias / Data Thirst Ltd 
+
+#> 
+Function Export-DatabricksJobs {  
+    [cmdletbinding()]
+    Param(
+        [parameter(Mandatory = $false)][string]$BearerToken,    
+        [parameter(Mandatory = $false)][string]$Region,
+        [parameter(Mandatory = $true)][int[]] $jobIds,
+        [parameter(Mandatory = $true)][string]$LocalOutputPath,
+        [parameter(Mandatory = $false)][switch]$SettingsOnly
+    )
+
+    foreach ($jobId in $jobIds) {   
+        if ($PSBoundParameters.ContainsKey('SettingsOnly') -eq $true) {
+            $job = Get-DatabricksJob -BearerToken $BearerToken -Region $config.Region -JobId $jobId -SettingsOnly -Verbose
+            $jobAsJson = $job | ConvertTo-Json
+            $jobFileName = ($job.name -replace '[\W]', '_') + '.json'
+        }
+        else {
+            $job = Get-DatabricksJob -BearerToken $BearerToken -Region $config.Region -JobId $jobId -Verbose
+            $jobAsJson = $job | ConvertTo-Json
+            $jobFileName = ($job.settings.name -replace '[\W]', '_') + '.json'
+        }
+        $LocalExportPath = Join-Path $LocalOutputPath $jobFileName
+        Write-Verbose "Exporting job to $LocalExportPath"
+        New-Item -force -path $LocalExportPath -value $jobAsJson -type file | out-null
+    }
+}

--- a/Public/Get-DatabricksJob.ps1
+++ b/Public/Get-DatabricksJob.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+Retrieve Job Settings
+
+.DESCRIPTION
+Retrieves job Setting by ID
+.PARAMETER BearerToken
+Your Databricks Bearer token to authenticate to your workspace (see User Settings in Datatbricks WebUI)
+
+.PARAMETER Region
+Azure Region - must match the URL of your Databricks workspace, example northeurope
+
+.PARAMETER JobId
+The ID of the job
+
+.PARAMETER SettingsOnly
+Returnso nly the settings. useful if you want to export the settings of a job to source control.
+
+.EXAMPLE
+Get Job
+PS C:\> Get-DatabricksJob -BearerToken $BearerToken -Region $Region -JobId "MyTestJob"
+
+Get Job With Settings Only
+PS C:\> Get-DatabricksJob -BearerToken $BearerToken -Region $Region -JobId "MyTestJob" -SettingsOnly
+
+.NOTES
+Author: Simon D'Morias / Data Thirst Ltd 
+
+#>  
+
+Function Get-DatabricksJob
+{ 
+    param (
+        [parameter(Mandatory = $false)][string]$BearerToken, 
+        [parameter(Mandatory = $false)][string]$Region,
+        [parameter(Mandatory = $true)][string]$JobId,
+        [parameter(Mandatory = $false)][switch]$SettingsOnly
+    ) 
+
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $Headers = GetHeaders $PSBoundParameters 
+    
+    Try {
+        $Job = Invoke-RestMethod -Method Get -Uri "$global:DatabricksURI/api/2.0/jobs/get?job_id=$JobId" -Headers $Headers
+    }
+    Catch {
+        Write-Output "StatusCode:" $_.Exception.Response.StatusCode.value__ 
+        Write-Output "StatusDescription:" $_.Exception.Response.StatusDescription
+        Write-Error $_.ErrorDetails.Message
+    }
+
+    if($PSBoundParameters.ContainsKey('SettingsOnly') -eq $false)  {
+        Write-Verbose "Returning Job $($job.settings.name)"
+        Return $Job
+    }
+    else{
+        Write-Verbose "Returning Job Settings for $($Job.settings.name)"
+        Return $job.Settings
+    }
+
+}
+    

--- a/Tests/Export-DatabricksJobs.tests.ps1
+++ b/Tests/Export-DatabricksJobs.tests.ps1
@@ -35,11 +35,7 @@ Describe "Export-DatabricksJobs" {
         New-Item $LocalOutputPath -ItemType Directory -Force | out-Null
         $LocalOutputPath = Resolve-Path $LocalOutputPath
     }
-# Write-Host "here"
-#     $referenceObj = Get-Content -Path ("$LocalOutputPath\DummyJob2.json") | ConvertFrom-Json
-#     $DifferenceObj = Get-Content -Path ('Samples\DummyJobs\dummyJob2.json') | ConvertFrom-Json
-#     $whatIs = Compare-Object -ReferenceObject $referenceObj -DifferenceObject $DifferenceObj -IncludeEqual
-Write-Host $whatIs
+
     It "Download 2 Jobs, and content matches" {
         Export-DatabricksJobs -bearerToken $bearerToken -Region $config.Region -JobIds $global:JobIds -LocalOutputPath $LocalOutputPath -SettingsOnly -Verbose
         $Count = (Get-ChildItem -Path $LocalOutputPath).Count
@@ -60,5 +56,7 @@ Write-Host $whatIs
 
     AfterAll {
         Remove-Item $LocalOutputPath -Force -Recurse
+        Remove-DatabricksJob -JobId $global:JobId1
+        Remove-DatabricksJob -JobId $global:JobId2
     }
 }

--- a/Tests/Export-DatabricksJobs.tests.ps1
+++ b/Tests/Export-DatabricksJobs.tests.ps1
@@ -1,0 +1,64 @@
+param(
+    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "ServicePrincipal"
+)
+
+Set-Location $PSScriptRoot
+Import-Module "..\azure.databricks.cicd.tools.psd1" -Force
+$Config = (Get-Content '.\config.json' | ConvertFrom-Json)
+
+switch ($mode) {
+    ("Bearer") {
+        Connect-Databricks -Region $Config.Region -BearerToken $Config.BearerToken
+    }
+    ("ServicePrincipal") {
+        Connect-Databricks -Region $Config.Region -DatabricksOrgId $Config.DatabricksOrgId -ApplicationId $Config.ApplicationId -Secret $Config.Secret -TenantId $Config.TenantId
+    }
+}
+
+
+Describe "Export-DatabricksJobs" {
+
+    BeforeAll {
+        $jobFile1 = 'Samples\DummyJobs\dummyJob.json'
+        $global:jobSettings1 = Get-Content $jobFile1
+        $global:JobId1 = Add-DatabricksNotebookJob -JobName "DummyJob" `
+            -InputObject ($jobSettings1 | ConvertFrom-Json) -Verbose
+
+        $jobFile2 = 'Samples\DummyJobs\dummyJob2.json'
+        $global:jobSettings2 = Get-Content $jobFile2
+        $global:JobId2 = Add-DatabricksNotebookJob -JobName "DummyJob2" `
+            -InputObject ($jobSettings2 | ConvertFrom-Json) -Verbose
+        $global:JobIds = @()
+        $global:JobIds = $global:JobId1, $global:JobId2
+
+        $LocalOutputPath = 'Samples\DummyJobsDownExported\'
+        New-Item $LocalOutputPath -ItemType Directory -Force | out-Null
+        $LocalOutputPath = Resolve-Path $LocalOutputPath
+    }
+# Write-Host "here"
+#     $referenceObj = Get-Content -Path ("$LocalOutputPath\DummyJob2.json") | ConvertFrom-Json
+#     $DifferenceObj = Get-Content -Path ('Samples\DummyJobs\dummyJob2.json') | ConvertFrom-Json
+#     $whatIs = Compare-Object -ReferenceObject $referenceObj -DifferenceObject $DifferenceObj -IncludeEqual
+Write-Host $whatIs
+    It "Download 2 Jobs, and content matches" {
+        Export-DatabricksJobs -bearerToken $bearerToken -Region $config.Region -JobIds $global:JobIds -LocalOutputPath $LocalOutputPath -SettingsOnly -Verbose
+        $Count = (Get-ChildItem -Path $LocalOutputPath).Count
+        $Count | Should -Be 2
+    }
+
+    It "Imported and Exported File Contents Match"{
+        $referenceObj2 = Get-Content -Path ("$LocalOutputPath\DummyJob2.json") | ConvertFrom-Json
+        $DifferenceObj2 = Get-Content -Path ('Samples\DummyJobs\dummyJob2.json') | ConvertFrom-Json
+        $DummyContent2 = Compare-Object -ReferenceObject $referenceObj2 -DifferenceObject $DifferenceObj2 -IncludeEqual
+        $DummyContent2 | Should -BeExactly "@{InputObject=; SideIndicator===}"
+
+        $referenceObj1 = Get-Content -Path ("$LocalOutputPath\DummyJob.json") | ConvertFrom-Json
+        $DifferenceObj1 = Get-Content -Path ('Samples\DummyJobs\dummyJob.json') | ConvertFrom-Json
+        $DummyContent1 = Compare-Object -ReferenceObject $referenceObj1 -DifferenceObject $DifferenceObj1 -IncludeEqual
+        $DummyContent1 | Should -BeExactly "@{InputObject=; SideIndicator===}"
+    }
+
+    AfterAll {
+        Remove-Item $LocalOutputPath -Force -Recurse
+    }
+}

--- a/Tests/Samples/DummyJobs/dummyJob.json
+++ b/Tests/Samples/DummyJobs/dummyJob.json
@@ -1,0 +1,27 @@
+{
+    "name": "dummyJob",
+    "existing_cluster_id": "2009-143475-skull768",
+    "email_notifications": {
+      "on_start": [
+        "necrozma@bzzzt.io"
+      ],
+      "on_success": [
+        "123@fakedomain.io",
+        "necrozma@bzzzt.io"
+      ],
+      "on_failure": [
+        "123@fakedomain.io",
+        "necrozma@bzzzt.io"
+      ]
+    },
+    "timeout_seconds": 0,
+    "schedule": {
+      "quartz_cron_expression": "0 0 7 ? * 2",
+      "timezone_id": "Europe/London"
+    },
+    "notebook_task": {
+      "notebook_path": "/DEV/PATH/TO/NOTEBOOk",
+      "revision_timestamp": 0
+    },
+    "max_concurrent_runs": 1
+  }

--- a/Tests/Samples/DummyJobs/dummyJob2.json
+++ b/Tests/Samples/DummyJobs/dummyJob2.json
@@ -1,0 +1,61 @@
+{
+    "name": "dummyJob2",
+    "new_cluster": {
+      "spark_version": "5.5.x-scala2.11",
+      "spark_conf": {
+        "spark.databricks.repl.allowedLanguages": "sql,python,r",
+        "spark.executor.heartbeatInterval": "60s",
+        "spark.databricks.delta.preview.enabled": "true",
+        "spark.network.timeout": "720s",
+        "spark.databricks.cluster.profile": "serverless"
+      },
+      "node_type_id": "Standard_D16s_v3",
+      "driver_node_type_id": "Standard_D16s_v3",
+      "custom_tags": {
+        "jobcluster": "true",
+        "source": "tomato",
+        "project": "bob"
+      },
+      "spark_env_vars": {
+        "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
+      },
+      "enable_elastic_disk": true,
+      "autoscale": {
+        "min_workers": 1,
+        "max_workers": 2
+      }
+    },
+    "libraries": [
+      {
+        "whl": "dbfs:/FileStore/jars/110566a7_e14f_4691_9f98_94f1620bc071/azure_storage_blob-2.1.0-py2.py3-none-any.whl"
+      },
+      {
+        "whl": "dbfs:/FileStore/jars/08a0a5c3_07de_4fe6_9de3_19640f2ccd54/boto3-1.9.249-py2.py3-none-any.whl"
+      },
+      {
+        "pypi": {
+          "package": "cryptography==1.5"
+        }
+      },
+      {
+        "egg": "dbfs:/FileStore/jars/dd7c0220_5a5b_4378_82d8_d378830a899e-jars_735a2ecf_f11d_4412_b83c_a30e7b23298a_engineering_0_7_py3_7_4efca__1_-e4943.egg"
+      },
+      {
+        "whl": "dbfs:/FileStore/jars/f9bcde31_715a_4d04_8f67_76355f952739/paramiko-2.4.2-py2.py3-none-any.whl"
+      }
+    ],
+    "email_notifications": {},
+    "timeout_seconds": 0,
+    "notebook_task": {
+      "notebook_path": "/DEV/PATH/NOTEBOOK",
+      "base_parameters": {
+        "notebook": "THISONE",
+        "project": "THATONE"
+      }
+    },
+    "max_concurrent_runs": 1,
+    "schedule": {
+      "quartz_cron_expression": "0 0 18 * * ?",
+      "timezone_id": "Europe/London"
+    }
+  }

--- a/azure.databricks.cicd.tools.psd1
+++ b/azure.databricks.cicd.tools.psd1
@@ -82,7 +82,7 @@
     'Remove-DatabricksLibrary', 'Get-DatabricksServicePrincipals', 'Add-DatabricksUser', 'Set-DatabricksPermission',
     'Get-DatabricksPermissionLevels', 'Invoke-DatabricksAPI', 'Remove-DatabricksSecret', 'Get-DatabricksWorkspaceFolder',
     'Get-DatabricksInstancePool', 'Add-DatabricksInstancePool', 'Remove-DatabricksInstancePool',
-    'New-DatabricksBearerToken', 'Remove-DatabricksBearerToken', 'Get-DatabricksBearerToken'
+    'New-DatabricksBearerToken', 'Remove-DatabricksBearerToken', 'Get-DatabricksBearerToken', 'Get-DatabricksJob', 'Export-DatabricksJobs'
 
     # Cmdlets to export from this module
     CmdletsToExport = '*'


### PR DESCRIPTION
add-databicksnotebook takes settings as one object instead of switche…s; export jobs by job id and save settings only.

This is how I'd like to manage my Jobs in source -  

1. create the job in the portal, because it's easy. 

2. download the job via the API, save it as a json file in a folder in my repo. 

3. pass the json to the API in a deployment. 

wrt point 3 - The trouble is is that ```Add-DatabricksNotebookJob``` will take a bunch of parameters and create the json object for you. 

So then either 
**A.**  have yet another script that takes the job json stored locally, figure out which params to run then use ```Add-DatabricksNotebookJob``` to deploy the job (which then turns it back into json, so what's the point 
**B.** store the jobs as cmds in like a csv or something else to run the ```Add-DatabricksNotebookJob``` for each job. 
**C.** Alter ```Add-DatabricksNotebookJob``` to accept a PSCustomObject that contains everything required to make the job, which is the change I have submitted to the cmdlet.

wrt point 2 - all I need to save is the ```settings``` part of the Job, so ```Get-DatabricksJob``` has been created to get the Job based on a jobId and has the option to output only the settings of the response. And ```Export-DataBricksJobs``` uses this function to loop through an array of JobIds and save them to a local directory, using ```name``` stored in the settings to use as the filename.