### PR TITLE
Able to list all secrets under a scope; remove scope has optional check to fail if not empty

### DIFF
--- a/Public/Add-DatabricksLibrary.ps1
+++ b/Public/Add-DatabricksLibrary.ps1
@@ -106,9 +106,16 @@ Function Add-DatabricksLibrary {
         $Body = $InputObject
     }
 
-    $BodyText = $Body | ConvertTo-Json -Depth 10
+    $BodyText = $Body | ConvertTo-Json -Depth 100
 
     Write-Verbose "Request Body: $BodyText"
     Write-Verbose "Installing library $LibraryType with setting $LibrarySettings to REST API: $uri"
-    Invoke-RestMethod -Uri $uri -Body $BodyText -Method 'POST' -Headers $Headers
+    try {
+        Invoke-RestMethod -Uri $uri -Body $BodyText -Method 'POST' -Headers $Headers
+    }
+    catch {
+        Write-Output "StatusCode:" $_.Exception.Response.StatusCode.value__ 
+        Write-Output "StatusDescription:" $_.Exception.Response.StatusDescription
+        Write-Error $_.ErrorDetails.Message
+    }
 }

--- a/Public/Add-DatabricksLibrary.ps1
+++ b/Public/Add-DatabricksLibrary.ps1
@@ -38,6 +38,35 @@ If cran, specification of a CRAN library to be installed.
 The cluster to install the library to. Note that the API does not support auto installing to
 all clusters. See Get-DatabricksClusters. 
 
+.PARAMETER InpputObject
+Can take an object that is correctly formatted so that more than one library can be added.
+
+{
+  "cluster_id": "10201-my-cluster",
+  "libraries": [
+    {
+      "jar": "dbfs:/mnt/libraries/library.jar"
+    },
+    {
+      "egg": "dbfs:/mnt/libraries/library.egg"
+    }
+  ]
+}
+
+Output from Get-DatabricksLibraries can also be piped - 
+
+$rcl = Get-DatabricksLibraries -ClusterId $clusterId -ReturnCluster
+    for ($i = 0; $i -lt $rcl.library_statuses.Length; $i ++) {
+        $rcl.library_statuses[$i].psobject.properties.remove('status')
+        $rcl.library_statuses[$i].psobject.properties.remove('is_library_for_all_clusters')
+    } 
+    $LibsToAdd = [PSCustomObject]@{
+        cluster_id     = $anotherClusterId
+        libraries = $rcl.library_statuses.library
+    }
+$LibsToAdd | Add-DatabricksLibrary -Verbose
+
+
 .EXAMPLE
 C:\PS> Add-DatabricksLibrary -BearerToken $BearerToken -Region $Region -LibraryType "jar" -LibrarySettings "dbfs:/mnt/libraries/library.jar" -ClusterId "bob-1234"
 

--- a/Public/Add-DatabricksLibrary.ps1
+++ b/Public/Add-DatabricksLibrary.ps1
@@ -54,45 +54,56 @@ Author: Simon D'Morias / Data Thirst Ltd
 #>
 
 Function Add-DatabricksLibrary {  
-    [cmdletbinding()]
+    [cmdletbinding(DefaultParameterSetName = 'Settings')]
     param (
-        [parameter(Mandatory = $false)][string]$BearerToken,    
-        [parameter(Mandatory = $false)][string]$Region,
-        [Parameter(Mandatory = $true)][ValidateSet('jar','egg','maven','pypi','cran', 'whl')][string]$LibraryType,
-        [parameter(Mandatory = $true)][string]$LibrarySettings,
-        [parameter(Mandatory = $true)][string]$ClusterId
+        [Parameter(ParameterSetName = 'InputObject', Mandatory = $false)]
+        [Parameter(ParameterSetName = 'Settings', Mandatory = $false)]
+        [string]$BearerToken, 
+        [Parameter(ParameterSetName = 'InpputObject', Mandatory = $false)]
+        [Parameter(ParameterSetName = 'Settings', Mandatory = $false)]
+        [string]$Region,
+        [parameter(ParameterSetName = 'InputObject', ValueFromPipeline, Mandatory = $true)][object]$InputObject,
+        [parameter(ParameterSetName = 'Settings', Mandatory = $true)][string]$ClusterId,
+        [Parameter(ParameterSetName = 'Settings', Mandatory = $true)][ValidateSet('jar', 'egg', 'maven', 'pypi', 'cran', 'whl')][string]$LibraryType,
+        [parameter(ParameterSetName = 'Settings', Mandatory = $true)][string]$LibrarySettings
     ) 
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $Headers = GetHeaders $PSBoundParameters
     
 
-    $uri ="$global:DatabricksURI/api/2.0/libraries/install"
+    $uri = "$global:DatabricksURI/api/2.0/libraries/install"
 
-    $Body = @{"cluster_id"=$ClusterId}
+    if ($PSBoundParameters.ContainsKey('InputObject') -eq $false) {
 
-    if (($LibrarySettings -notmatch '{') -and ($LibraryType -eq "pypi")) {
-        #Pypi and only string passed - try as simple name
-        Write-Verbose "Converting to pypi JSON request"
-        $LibrarySettings = '{package: "' + $LibrarySettings + '"}'
-    }
+        $Body = @{"cluster_id" = $ClusterId }
 
-    if ($LibrarySettings -match '{'){
-        # Settings are JSON else assume String (name of library)
-        Write-Verbose "Request is in JSON"
-        $Libraries = @()
-        $Library = @{}
-        $Library[$LibraryType]= ($LibrarySettings | ConvertFrom-Json)
-        $Libraries += $Library
-        $Body['libraries'] = $Libraries
+        if (($LibrarySettings -notmatch '{') -and ($LibraryType -eq "pypi")) {
+            #Pypi and only string passed - try as simple name
+            Write-Verbose "Converting to pypi JSON request"
+            $LibrarySettings = '{package: "' + $LibrarySettings + '"}'
+        }
+
+        if ($LibrarySettings -match '{') {
+            # Settings are JSON else assume String (name of library)
+            Write-Verbose "Request is in JSON"
+            $Libraries = @()
+            $Library = @{}
+            $Library[$LibraryType] = ($LibrarySettings | ConvertFrom-Json)
+            $Libraries += $Library
+            $Body['libraries'] = $Libraries
+        }
+        else {
+            Write-Verbose "Request is a string"
+            $Libraries = @()
+            $Library = @{}
+            $Library[$LibraryType] = $LibrarySettings
+            $Libraries += $Library
+            $Body['libraries'] = $Libraries
+        }
     }
     else {
-        Write-Verbose "Request is a string"
-        $Libraries = @()
-        $Library = @{}
-        $Library[$LibraryType]= $LibrarySettings
-        $Libraries += $Library
-        $Body['libraries'] = $Libraries
+        $Body = $InputObject
     }
 
     $BodyText = $Body | ConvertTo-Json -Depth 10

--- a/Public/Get-DatabricksLibraries.ps1
+++ b/Public/Get-DatabricksLibraries.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-Get a list of Libraries and thier statuses for a Databricks cluster
+Get a list of Libraries and their statuses for a Databricks cluster
 
 .DESCRIPTION
-Get a list of Libraries and thier statuses for a Databricks cluster
+Get a list of Libraries and their statuses for a Databricks cluster
 
 .PARAMETER BearerToken
 Your Databricks Bearer token to authenticate to your workspace (see User Settings in Datatbricks WebUI)
@@ -13,6 +13,9 @@ Azure Region - must match the URL of your Databricks workspace, example northeur
 
 .PARAMETER ClusterId
 ClusterId for existing Databricks cluster. Does not need to be running. See Get-DatabricksClusters.
+
+.PARAMETER returnCluster
+Switch that returns the entire object.
 
 .EXAMPLE
 PS C:\> Get-DatabricksLibraries -BearerToken $BearerToken -Region $Region -ClusterId 'Bob-1234'

--- a/Public/Get-DatabricksLibraries.ps1
+++ b/Public/Get-DatabricksLibraries.ps1
@@ -22,13 +22,13 @@ Author: Simon D'Morias / Data Thirst Ltd
 
 #>  
 
-Function Get-DatabricksLibraries
-{ 
+Function Get-DatabricksLibraries { 
     [cmdletbinding()]
     param (
         [parameter(Mandatory = $false)][string]$BearerToken, 
         [parameter(Mandatory = $false)][string]$Region,
-        [parameter(Mandatory = $true)][string]$ClusterId
+        [parameter(Mandatory = $true)][string]$ClusterId,
+        [parameter(Mandatory = $false)][switch]$returnCluster
     ) 
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -45,7 +45,12 @@ Function Get-DatabricksLibraries
         Write-Output "StatusDescription:" $_.Exception.Response.StatusDescription
         Write-Error $_.ErrorDetails.Message
     }
+    if ($PSBoundParameters.ContainsKey('returnCluster') -eq $false) {
 
-    Return $Libraries.library_statuses
+        Return $Libraries.library_statuses
+    }
+    else {
+        $Libraries
+    }
 }
     

--- a/Public/Get-DatabricksSecretByScope.ps1
+++ b/Public/Get-DatabricksSecretByScope.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-List all Secret Scopes
+List all Secrets By Scope
 
 .DESCRIPTION
-List all Secret Scopes. Or search for one
+List all Secrets of a scope. Or search for one secret by key.
 
 .PARAMETER BearerToken
 Your Databricks Bearer token to authenticate to your workspace (see User Settings in Datatbricks WebUI)
@@ -12,14 +12,19 @@ Your Databricks Bearer token to authenticate to your workspace (see User Setting
 Azure Region - must match the URL of your Databricks workspace, example northeurope
 
 .PARAMETER ScopeName
-Optional. Search for a specific scope by name
+Return secrets under this scope.
+
+.PARAMETER SecretKey
+Optional. Search for a specific secret by key
 
 
 .EXAMPLE
 PS C:\> Get-DatabricksSecretScopes -BearerToken $BearerToken -Region $Region -ScopeName "MyScope"
 
+PS C:\> Get-DatabricksSecretScopes -BearerToken $BearerToken -Region $Region -ScopeName "MyScope" -Secretkey "secretName"
+
 .NOTES
-Author: Simon D'Morias / Data Thirst Ltd 
+Author: Richie Lee / @richiebzzzt 
 
 #>  
 Function Get-DatabricksSecretByScope { 

--- a/Public/Remove-DatabricksLibrary.ps1
+++ b/Public/Remove-DatabricksLibrary.ps1
@@ -96,5 +96,12 @@ Function Remove-DatabricksLibrary {
 
     Write-Verbose "Request Body: $BodyText"
     Write-Verbose "Uninstalling library $LibraryType with setting $LibrarySettings to REST API: $uri"
-    Invoke-RestMethod -Uri "$global:DatabricksURI/$uri" -Body $BodyText -Method 'POST' -Headers $Headers
+    try {
+        Invoke-RestMethod -Uri "$global:DatabricksURI/$uri" -Body $BodyText -Method 'POST' -Headers $Headers
+    }
+    catch {
+        Write-Output "StatusCode:" $_.Exception.Response.StatusCode.value__ 
+        Write-Output "StatusDescription:" $_.Exception.Response.StatusDescription
+        Write-Error $_.ErrorDetails.Message
+    }
 }

--- a/Public/Remove-DatabricksLibrary.ps1
+++ b/Public/Remove-DatabricksLibrary.ps1
@@ -32,6 +32,34 @@ If maven, specification of a Maven library to be installed. For example: { "coor
 
 If cran, specification of a CRAN library to be installed.
 
+.PARAMETER InputObject
+Can take an object that is correctly formatted so that more than one library can be removed.
+
+{
+  "cluster_id": "10201-my-cluster",
+  "libraries": [
+    {
+      "jar": "dbfs:/mnt/libraries/library.jar"
+    },
+    {
+      "egg": "dbfs:/mnt/libraries/library.egg"
+    }
+  ]
+}
+
+Output from Get-DatabricksLibraries can also be piped - 
+
+$rcl = Get-DatabricksLibraries -ClusterId $clusterId -ReturnCluster
+    for ($i = 0; $i -lt $rcl.library_statuses.Length; $i ++) {
+        $rcl.library_statuses[$i].psobject.properties.remove('status')
+        $rcl.library_statuses[$i].psobject.properties.remove('is_library_for_all_clusters')
+    } 
+    $LibsToRemove = [PSCustomObject]@{
+        cluster_id     = $clusterId
+        libraries = $rcl.library_statuses.library
+    }
+$LibsToRemove | Remove-DatabricksLibrary -Verbose
+
 .EXAMPLE
 PS C:\> Remove-DatabricksLibrary -BearerToken $BearerToken -Region $Region -ClusterId 'Bob-1234'
 

--- a/Public/Remove-DatabricksSecretScope.ps1
+++ b/Public/Remove-DatabricksSecretScope.ps1
@@ -38,7 +38,7 @@ Function Remove-DatabricksSecretScope {
     $secrets = Get-DatabricksSecretByScope -BearerToken $BearerToken -Region $Region -ScopeName $ScopeName
 
     If ($PSBoundParameters.ContainsKey('RemoveEmptyOnly') -eq $true) {
-        if ($secrets.secrets.count -gt 0) {
+        if ($secrets.count -gt 0) {
             Write-Output "Scope $ScopeName has $($secrets.count) secret and is not empty!"
             Throw
         }
@@ -50,8 +50,10 @@ Function Remove-DatabricksSecretScope {
     $Body = @{}
     $Body['scope'] = $ScopeName
     $BodyText = $Body | ConvertTo-Json -Depth 10
-    $SecretNames  = $secrets.key -join "`n"
-    Write-Verbose "Following secrets will be deleted... `n $SecretNames"
+    if ($secrets.count -gt 0) {
+        $SecretNames = $secrets.key -join "`n"
+        Write-Verbose "Following secrets will be deleted... `n $SecretNames"
+    }
     Try {
         Invoke-RestMethod -Method Post -Body $BodyText -Uri "$global:DatabricksURI/api/2.0/secrets/scopes/delete" -Headers $Headers
     }

--- a/Public/Remove-DatabricksSecretScope.ps1
+++ b/Public/Remove-DatabricksSecretScope.ps1
@@ -14,6 +14,9 @@ Azure Region - must match the URL of your Databricks workspace, example northeur
 .PARAMETER ScopeName
 Name of the scope to remove, will not error if it does not exist
 
+.PARAMETER RemoveEmptyOnly
+Switch that if included will check if scope is not empty.
+
 .EXAMPLE
 PS C:\> Remove-DatabricksSecretScope -BearerToken $BearerToken -Region $Region -ScopeName "MyScope"
 
@@ -21,35 +24,41 @@ PS C:\> Remove-DatabricksSecretScope -BearerToken $BearerToken -Region $Region -
 Author: Simon D'Morias / Data Thirst Ltd
 #>  
 
-Function Remove-DatabricksSecretScope
-{ 
+Function Remove-DatabricksSecretScope { 
     [cmdletbinding()]
     param (
         [parameter(Mandatory = $false)][string]$BearerToken, 
         [parameter(Mandatory = $false)][string]$Region,
-        [parameter(Mandatory = $true)][string]$ScopeName
+        [parameter(Mandatory = $true)][string]$ScopeName,
+        [parameter(Mandatory = $false)][switch]$RemoveEmptyOnly
+
     ) 
+    $secrets = Get-DatabricksSecretByScope -BearerToken $BearerToken -Region $Region -ScopeName $ScopeName
+
+    If ($PSBoundParameters.ContainsKey('RemoveEmptyOnly') -eq $true) {
+        if ($secrets.secrets.count -gt 0) {
+            Write-Output "Scope $ScopeName has $($secrets.count) secret and is not empty!"
+            Throw
+        }
+    }
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $Headers = GetHeaders $PSBoundParameters 
-    
-    
+
     $Body = @{}
     $Body['scope'] = $ScopeName
-
     $BodyText = $Body | ConvertTo-Json -Depth 10
-    
+    $SecretNames  = $secrets.key -join "`n"
+    Write-Verbose "Following secrets will be deleted... `n $SecretNames"
     Try {
         Invoke-RestMethod -Method Post -Body $BodyText -Uri "$global:DatabricksURI/api/2.0/secrets/scopes/delete" -Headers $Headers
     }
     Catch {
         $err = $_.ErrorDetails.Message
-        if ($err.Contains('RESOURCE_DOES_NOT_EXIST'))
-        {
+        if ($err.Contains('RESOURCE_DOES_NOT_EXIST')) {
             Write-Verbose $err
         }
-        else
-        {
+        else {
             Write-Output "StatusCode:" $_.Exception.Response.StatusCode.value__ 
             Write-Output "StatusDescription:" $_.Exception.Response.StatusDescription
             Write-Error $err

--- a/Public/Remove-DatabricksSecretScope.ps1
+++ b/Public/Remove-DatabricksSecretScope.ps1
@@ -20,6 +20,8 @@ Switch that if included will check if scope is not empty.
 .EXAMPLE
 PS C:\> Remove-DatabricksSecretScope -BearerToken $BearerToken -Region $Region -ScopeName "MyScope"
 
+PS C:\> Remove-DatabricksSecretScope -BearerToken $BearerToken -Region $Region -ScopeName "MyScope" -RemoveEmptyOnly
+
 .NOTES
 Author: Simon D'Morias / Data Thirst Ltd
 #>  

--- a/Tests/Add-DatabricksLibrary.tests.ps1
+++ b/Tests/Add-DatabricksLibrary.tests.ps1
@@ -1,0 +1,35 @@
+param(
+    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "ServicePrincipal"
+)
+
+Set-Location $PSScriptRoot
+Import-Module "..\azure.databricks.cicd.tools.psd1" -Force
+$Config = (Get-Content '.\config.json' | ConvertFrom-Json)
+$libraryFile = 'Samples\DummyLibraries\dummylibraries.json'
+$libraries = (Get-Content -path $libraryFile -Raw) -replace '__cluster_id__', $Config.AddLibraryClusterId | ConvertFrom-Json
+
+switch ($mode) {
+    ("Bearer") {
+        Connect-Databricks -Region $Config.Region -BearerToken $Config.BearerToken
+    }
+    ("ServicePrincipal") {
+        Connect-Databricks -Region $Config.Region -DatabricksOrgId $Config.DatabricksOrgId -ApplicationId $Config.ApplicationId -Secret $Config.Secret -TenantId $Config.TenantId
+    }
+}
+
+Describe "Add-DatabricksLibrary" {
+    It "Add Libraries by file" {
+
+        $clusterLibrariesStatus = Get-DatabricksLibraries -ClusterId $Config.AddLibraryClusterId
+        $clusterLibrariesStatus.Length | Should Be 0
+        {Add-DatabricksLibrary -InputObject $libraries} | Should Not Throw
+        $clusterLibrariesStatus = Get-DatabricksLibraries -ClusterId $Config.AddLibraryClusterId
+        $clusterLibrariesStatus.Length | Should Be 12
+    }
+    AfterAll{
+        Remove-DatabricksLibrary -InputObject $libraries
+        Start-Sleep -Seconds 10
+        Restart-DatabricksCluster -ClusterId $Config.AddLibraryClusterId
+    }
+}
+

--- a/Tests/Add-DatabricksLibrary.tests.ps1
+++ b/Tests/Add-DatabricksLibrary.tests.ps1
@@ -1,5 +1,5 @@
 param(
-    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "Bearer"
+    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "ServicePrincipal"
 )
 
 Set-Location $PSScriptRoot
@@ -28,7 +28,6 @@ Describe "Add-DatabricksLibrary" {
     }
     It "Add Libraries by InputObject" {
         $clusterLibrariesStatus = Get-DatabricksLibraries -ClusterId $Config.AddLibraryClusterId -ReturnCluster
-        $clusterLibrariesStatus
         for ($i = 0; $i -lt $clusterLibrariesStatus.library_statuses.Length; $i ++) {
             $clusterLibrariesStatus.library_statuses[$i].psobject.properties.remove('status')
             $clusterLibrariesStatus.library_statuses[$i].psobject.properties.remove('is_library_for_all_clusters')

--- a/Tests/Get-DatabricksSecretByScope.tests.ps1
+++ b/Tests/Get-DatabricksSecretByScope.tests.ps1
@@ -23,12 +23,21 @@ Describe "Get-DatabricksSecretByScope" {
         Set-DatabricksSecret -ScopeName $ScopeName -SecretName 'TestSecretName' -SecretValue 'ohdear'
         Set-DatabricksSecret -ScopeName $ScopeName -SecretName 'AnotherTestSecretName' -SecretValue 'ohdear'
     }
-    It "Get DataBricks Secrets - should be two results" {
+    It "Get all DataBricks Secrets under one scope" {
         $databricksSecrets = Get-DatabricksSecretByScope -ScopeName $ScopeName -Verbose
         $databricksSecrets.count | Should Be 2
     }
-    It "Delete non existent should not fail" {
+    It "Get non existent scope should not fail" {
         Get-DatabricksSecretByScope -ScopeName "Doesntexist"  -Verbose
+    }
+    It "Get Single Secret from Scope" {
+        $databricksSecrets = Get-DatabricksSecretByScope -ScopeName $ScopeName -SecretKey 'TestSecretName' -Verbose
+        $databricksSecrets.count | Should Be 1
+    }
+
+    It "Get Single Secret from Scope should not fail" {
+        $databricksSecrets = Get-DatabricksSecretByScope -ScopeName $ScopeName -SecretKey 'doesntexist' -Verbose
+        $databricksSecrets.count | Should Be 0
     }
     AfterAll{
         Remove-DatabricksSecretScope -ScopeName $ScopeName -Verbose

--- a/Tests/Get-DatabricksSecretByScope.tests.ps1
+++ b/Tests/Get-DatabricksSecretByScope.tests.ps1
@@ -1,0 +1,36 @@
+param(
+    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "ServicePrincipal"
+)
+
+Set-Location $PSScriptRoot
+Import-Module "..\azure.databricks.cicd.tools.psd1" -Force
+$Config = (Get-Content '.\config.json' | ConvertFrom-Json)
+
+switch ($mode) {
+    ("Bearer") {
+        Connect-Databricks -Region $Config.Region -BearerToken $Config.BearerToken
+    }
+    ("ServicePrincipal") {
+        Connect-Databricks -Region $Config.Region -DatabricksOrgId $Config.DatabricksOrgId -ApplicationId $Config.ApplicationId -Secret $Config.Secret -TenantId $Config.TenantId
+    }
+}
+
+$ScopeName = "DataThirstTest123"
+
+Describe "Get-DatabricksSecretByScope" {
+    BeforeAll {
+        Add-DatabricksSecretScope -ScopeName $ScopeName  -Verbose
+        Set-DatabricksSecret -ScopeName $ScopeName -SecretName 'TestSecretName' -SecretValue 'ohdear'
+        Set-DatabricksSecret -ScopeName $ScopeName -SecretName 'AnotherTestSecretName' -SecretValue 'ohdear'
+    }
+    It "Get DataBricks Secrets - should be two results" {
+        $databricksSecrets = Get-DatabricksSecretByScope -ScopeName $ScopeName -Verbose
+        $databricksSecrets.count | Should Be 2
+    }
+    It "Delete non existent should not fail" {
+        Get-DatabricksSecretByScope -ScopeName "Doesntexist"  -Verbose
+    }
+    AfterAll{
+        Remove-DatabricksSecretScope -ScopeName $ScopeName -Verbose
+    }
+}

--- a/Tests/Remove-DatabricksLibrary.tests.ps1
+++ b/Tests/Remove-DatabricksLibrary.tests.ps1
@@ -16,20 +16,42 @@ switch ($mode) {
 }
 
 Describe "Remove-DatabricksLibrary" {
-    It "Remove Library by file" {
+    BeforeEach {
         $libraryFile = 'Samples\DummyLibraries\dummylibraries.json'
         $libraries = (Get-Content -path $libraryFile -Raw) -replace '__cluster_id__', $Config.RemoveLibraryClusterId | ConvertFrom-Json
         Add-DatabricksLibrary -InputObject $libraries
-        Start-Sleep -Seconds 20
-        {Remove-DatabricksLibrary -InputObject $libraries} | Should Not Throw
-        Start-Sleep -Seconds 20
+        Start-Sleep -Seconds 30
+    }
+    It "Remove Libraries by file" {
+        { Remove-DatabricksLibrary -InputObject $libraries } | Should Not Throw
+    }
+
+    It "Remove Libraries by InputObject" {
+        $RemoveClusterLib = Get-DatabricksLibraries -ClusterId $Config.RemoveLibraryClusterId
+        $RemoveClusterLib.Length | Should Be 12
+        foreach ($cls in $RemoveClusterLib) {
+            $cls.status | Should Be 'INSTALLED'
+        }
+        $rcl = Get-DatabricksLibraries -ClusterId $Config.RemoveLibraryClusterId -ReturnCluster
+        for ($i = 0; $i -lt $rcl.library_statuses.Length; $i ++) {
+            $rcl.library_statuses[$i].psobject.properties.remove('status')
+            $rcl.library_statuses[$i].psobject.properties.remove('is_library_for_all_clusters')
+        } 
+        $LibsToRemove = [PSCustomObject]@{
+            cluster_id     = $Config.RemoveLibraryClusterId
+            libraries = $rcl.library_statuses.library
+        }
+        {$LibsToRemove | Remove-DatabricksLibrary -Verbose} | Should Not Throw
+    }
+    AfterEach {
+        Start-Sleep -Seconds 40
         $clusterLibrariesStatus = Get-DatabricksLibraries -ClusterId $Config.RemoveLibraryClusterId
         foreach ($cls in $clusterLibrariesStatus) {
             $cls.status | Should Be 'UNINSTALL_ON_RESTART'
         }
         $clusterLibrariesStatus.Length | Should Be 12
     }
-    AfterAll{
+    AfterAll {
         Restart-DatabricksCluster -ClusterId $Config.RemoveLibraryClusterId
     }
 }

--- a/Tests/Remove-DatabricksLibrary.tests.ps1
+++ b/Tests/Remove-DatabricksLibrary.tests.ps1
@@ -1,0 +1,35 @@
+param(
+    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "ServicePrincipal"
+)
+
+Set-Location $PSScriptRoot
+Import-Module "..\azure.databricks.cicd.tools.psd1" -Force
+$Config = (Get-Content '.\config.json' | ConvertFrom-Json)
+
+switch ($mode) {
+    ("Bearer") {
+        Connect-Databricks -Region $Config.Region -BearerToken $Config.BearerToken
+    }
+    ("ServicePrincipal") {
+        Connect-Databricks -Region $Config.Region -DatabricksOrgId $Config.DatabricksOrgId -ApplicationId $Config.ApplicationId -Secret $Config.Secret -TenantId $Config.TenantId
+    }
+}
+
+Describe "Remove-DatabricksLibrary" {
+    It "Remove Library by file" {
+        $libraryFile = 'Samples\DummyLibraries\dummylibraries.json'
+        $libraries = (Get-Content -path $libraryFile -Raw) -replace '__cluster_id__', $Config.RemoveLibraryClusterId | ConvertFrom-Json
+        Add-DatabricksLibrary -InputObject $libraries
+        Start-Sleep -Seconds 20
+        {Remove-DatabricksLibrary -InputObject $libraries} | Should Not Throw
+        Start-Sleep -Seconds 20
+        $clusterLibrariesStatus = Get-DatabricksLibraries -ClusterId $Config.RemoveLibraryClusterId
+        foreach ($cls in $clusterLibrariesStatus) {
+            $cls.status | Should Be 'UNINSTALL_ON_RESTART'
+        }
+        $clusterLibrariesStatus.Length | Should Be 12
+    }
+    AfterAll{
+        Restart-DatabricksCluster -ClusterId $Config.RemoveLibraryClusterId
+    }
+}

--- a/Tests/Remove-DatabricksSecretScope.tests.ps1
+++ b/Tests/Remove-DatabricksSecretScope.tests.ps1
@@ -1,16 +1,16 @@
 param(
-    [ValidateSet('Bearer','ServicePrincipal')][string]$Mode="ServicePrincipal"
+    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "ServicePrincipal"
 )
 
 Set-Location $PSScriptRoot
 Import-Module "..\azure.databricks.cicd.tools.psd1" -Force
 $Config = (Get-Content '.\config.json' | ConvertFrom-Json)
 
-switch ($mode){
-    ("Bearer"){
+switch ($mode) {
+    ("Bearer") {
         Connect-Databricks -Region $Config.Region -BearerToken $Config.BearerToken
     }
-    ("ServicePrincipal"){
+    ("ServicePrincipal") {
         Connect-Databricks -Region $Config.Region -DatabricksOrgId $Config.DatabricksOrgId -ApplicationId $Config.ApplicationId -Secret $Config.Secret -TenantId $Config.TenantId
     }
 }
@@ -18,14 +18,42 @@ switch ($mode){
 $ScopeName = "DataThirstTest123"
 
 Describe "Remove-DatabricksSecretScope" {
-    BeforeAll{
-        Add-DatabricksSecretScope -ScopeName $ScopeName  -Verbose
+    Context "Remove a Secret Scope and do not fail if secret scope does not exist." {
+        BeforeAll {
+            Add-DatabricksSecretScope -ScopeName $ScopeName  -Verbose
+        }
+        It "Simple addition" {
+            Remove-DatabricksSecretScope -ScopeName $ScopeName  -Verbose
+        }
+
+        It "Delete non existent should not fail" {
+            Remove-DatabricksSecretScope -ScopeName "Doesnt exist"  -Verbose
+        }
+
     }
-    It "Simple addition"{
-        Remove-DatabricksSecretScope -ScopeName $ScopeName  -Verbose
+    Context "Remove an empty Secret Scope." {
+        BeforeAll {
+            Add-DatabricksSecretScope -ScopeName $ScopeName  -Verbose
+        }
+        It "Remove Empty Only does not fail" {
+            Remove-DatabricksSecretScope -ScopeName $ScopeName -RemoveEmptyOnly -Verbose
+        }
     }
 
-    It "Delete non existent should not fail"{
-        Remove-DatabricksSecretScope -ScopeName "Doesnt exist"  -Verbose
+    Context "Removing Non Empty Scopes." {
+        BeforeEach {
+            Add-DatabricksSecretScope -ScopeName $ScopeName  -Verbose
+            Set-DatabricksSecret -ScopeName $ScopeName -SecretName 'TestSecretName' -SecretValue 'ohdear'
+            Set-DatabricksSecret -ScopeName $ScopeName -SecretName 'AnotherTestSecretName' -SecretValue 'ohdear'
+        }
+        It "Remove non-empty Scope does not fail" {
+            Remove-DatabricksSecretScope -ScopeName $ScopeName -Verbose
+        }
+        It "Remove non-empty Scope does fail" {
+            { Remove-DatabricksSecretScope -ScopeName $ScopeName -RemoveEmptyOnly -Verbose } | Should Throw
+        }
+        AfterAll {
+            Remove-DatabricksSecretScope -ScopeName $ScopeName -Verbose
+        }
     }
 }

--- a/Tests/Samples/DummyLibraries/dummylibraries.json
+++ b/Tests/Samples/DummyLibraries/dummylibraries.json
@@ -1,0 +1,78 @@
+{
+    "cluster_id": "__cluster_id__",
+    "libraries": [
+      {
+        "pypi": {
+          "repo": null,
+          "package": "boto3==1.9.249"
+        }
+      },
+      {
+        "pypi": {
+          "repo": null,
+          "package": "paramiko==2.7.1"
+        }
+      },
+      {
+        "pypi": {
+          "repo": null,
+          "package": "psycopg2==2.8.4"
+        }
+      },
+      {
+        "pypi": {
+          "repo": null,
+          "package": "chardet==2.3.0"
+        }
+      },
+      {
+        "pypi": {
+          "repo": null,
+          "package": "requests==2.11.1"
+        }
+      },
+      {
+        "pypi": {
+          "repo": null,
+          "package": "pytest==4.6.9"
+        }
+      },
+      {
+        "pypi": {
+          "repo": null,
+          "package": "azure-identity==1.3.1"
+        }
+      },
+      {
+        "pypi": {
+          "repo": null,
+          "package": "azure-storage-file-datalake==12.0.2"
+        }
+      },
+      {
+        "maven": {
+          "repo": null,
+          "exclusions": null,
+          "coordinates": "com.databricks:spark-xml_2.11:0.9.0"
+        }
+      },
+      {
+        "pypi": {
+          "repo": null,
+          "package": "azure-storage-blob==12.3.2"
+        }
+      },
+      {
+        "pypi": {
+          "repo": null,
+          "package": "google-cloud-bigquery==1.13.0"
+        }
+      },
+      {
+        "pypi": {
+          "repo": null,
+          "package": "google-cloud-storage==1.30.0"
+        }
+      }
+    ]
+  }

--- a/Tests/config.sample.json
+++ b/Tests/config.sample.json
@@ -10,5 +10,8 @@
     "SubscriptionId": "Azure subscription Id",
     "WorkspaceName": "Databricks workspace name (resource name in portal)",
     "ClusterId": "Test Cluster Id to use",
+    "AddLibraryClusterId": "Test Cluster Id to use for adding libraries. Should have no libraries installed. This cluster is restarted after test.",
+    "RemoveLibraryClusterId": "Test Cluster Id to use for removing libraries. Should have no libraries installed. This cluster is restarted after test.",
     "Username": "Existing user in workspace to apply permissions to"
 }
+

--- a/Tests/config.sample.json
+++ b/Tests/config.sample.json
@@ -11,6 +11,7 @@
     "WorkspaceName": "Databricks workspace name (resource name in portal)",
     "ClusterId": "Test Cluster Id to use",
     "AddLibraryClusterId": "Test Cluster Id to use for adding libraries. Should have no libraries installed. This cluster is restarted after test.",
+    "AddLibraryInputClusterId": "Test Cluster Id to use for adding libraries via InputObject. Should have no libraries installed. This cluster is restarted after test.",
     "RemoveLibraryClusterId": "Test Cluster Id to use for removing libraries. Should have no libraries installed. This cluster is restarted after test.",
     "Username": "Existing user in workspace to apply permissions to"
 }

--- a/azure.databricks.cicd.tools.psd1
+++ b/azure.databricks.cicd.tools.psd1
@@ -82,7 +82,8 @@
     'Remove-DatabricksLibrary', 'Get-DatabricksServicePrincipals', 'Add-DatabricksUser', 'Set-DatabricksPermission',
     'Get-DatabricksPermissionLevels', 'Invoke-DatabricksAPI', 'Remove-DatabricksSecret', 'Get-DatabricksWorkspaceFolder',
     'Get-DatabricksInstancePool', 'Add-DatabricksInstancePool', 'Remove-DatabricksInstancePool',
-    'New-DatabricksBearerToken', 'Remove-DatabricksBearerToken', 'Get-DatabricksBearerToken', 'Get-DatabricksJob', 'Export-DatabricksJobs'
+    'New-DatabricksBearerToken', 'Remove-DatabricksBearerToken', 'Get-DatabricksBearerToken', 'Get-DatabricksJob', 'Export-DatabricksJobs',
+    'Get-DatabricksSecretByScope'
 
     # Cmdlets to export from this module
     CmdletsToExport = '*'


### PR DESCRIPTION
```Get-DatabricksSecretByScope``` retrieves all secrets or a specific secret under a scope
```Remove-DatabricksSecretScope``` updated to include optional check to fail function if scope is not empty. Backwards compatable as default is to allow removing non-empty scopes.