### PR TITLE
Issue134 - Limit Pester Version

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "PowerShell: Launch Current File",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}",
+            "cwd": "${file}"
+        }
+    ]
+}

--- a/Tests/_InvokeTests.ps1
+++ b/Tests/_InvokeTests.ps1
@@ -1,8 +1,8 @@
 param(
     [ValidateSet('Bearer','ServicePrincipal')][string]$Mode="Bearer"
 )
-Install-Module Pester -MinimumVersion 4.4.2 -Scope CurrentUser -SkipPublisherCheck -Force
-Import-Module Pester -MinimumVersion 4.4.2
+Install-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 -Scope CurrentUser -SkipPublisherCheck -Force
+Import-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1
 
 Set-Location $PSScriptRoot
 $Edition = $PSVersionTable.PSEdition

--- a/azure-pipelines-fulltestsuite.yml
+++ b/azure-pipelines-fulltestsuite.yml
@@ -49,8 +49,8 @@ jobs:
       targetType: 'inline'
       script: |
         $Mode="Bearer"
-        Install-Module Pester -MinimumVersion 4.4.2 -Scope CurrentUser -SkipPublisherCheck -Force
-        Import-Module Pester -MinimumVersion 4.4.2 
+        Install-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 -Scope CurrentUser -SkipPublisherCheck -Force
+        Import-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1
         Set-Location "./Tests"
         Invoke-Pester -Script @{Path = "./*.tests.ps1"; Parameters = @{mode=$Mode}} -OutputFile "Win-PS-Bearer.xml" -OutputFormat NUnitXML
       pwsh: false
@@ -69,8 +69,8 @@ jobs:
       targetType: 'inline'
       script: |
         $Mode="ServicePrincipal"
-        Install-Module Pester -MinimumVersion 4.4.2 -Scope CurrentUser -SkipPublisherCheck -Force
-        Import-Module Pester -MinimumVersion 4.4.2 
+        Install-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 -Scope CurrentUser -SkipPublisherCheck -Force
+        Import-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1
         Set-Location "./Tests"
         Invoke-Pester -Script @{Path = "./*.tests.ps1"; Parameters = @{mode=$Mode}} -OutputFile "Win-PS-SP.xml" -OutputFormat NUnitXML
       pwsh: false
@@ -90,8 +90,8 @@ jobs:
       targetType: 'inline'
       script: |
         $Mode="Bearer"
-        Install-Module Pester -MinimumVersion 4.4.2 -Scope CurrentUser -SkipPublisherCheck -Force
-        Import-Module Pester -MinimumVersion 4.4.2 
+        Install-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 -Scope CurrentUser -SkipPublisherCheck -Force
+        Import-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 
         Set-Location "./Tests"
         Invoke-Pester -Script @{Path = "./*.tests.ps1"; Parameters = @{mode=$Mode}} -OutputFile "Win-PSCORE-Bearer.xml" -OutputFormat NUnitXML
       pwsh: true
@@ -110,8 +110,8 @@ jobs:
       targetType: 'inline'
       script: |
         $Mode="ServicePrincipal"
-        Install-Module Pester -MinimumVersion 4.4.2 -Scope CurrentUser -SkipPublisherCheck -Force
-        Import-Module Pester -MinimumVersion 4.4.2 
+        Install-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 -Scope CurrentUser -SkipPublisherCheck -Force
+        Import-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 
         Set-Location "./Tests"
         Invoke-Pester -Script @{Path = "./*.tests.ps1"; Parameters = @{mode=$Mode}} -OutputFile "Win-PSCORE-SP.xml" -OutputFormat NUnitXML
       pwsh: true
@@ -160,8 +160,8 @@ jobs:
       targetType: 'inline'
       script: |
         $Mode="Bearer"
-        Install-Module Pester -MinimumVersion 4.4.2 -Scope CurrentUser -SkipPublisherCheck -Force
-        Import-Module Pester -MinimumVersion 4.4.2 
+        Install-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 -Scope CurrentUser -SkipPublisherCheck -Force
+        Import-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 
         Set-Location "./Tests"
         Invoke-Pester -Script @{Path = "./*.tests.ps1"; Parameters = @{mode=$Mode}} -OutputFile "U-PS-Bearer.xml" -OutputFormat NUnitXML
       pwsh: true
@@ -180,8 +180,8 @@ jobs:
       targetType: 'inline'
       script: |
         $Mode="ServicePrincipal"
-        Install-Module Pester -MinimumVersion 4.4.2 -Scope CurrentUser -SkipPublisherCheck -Force
-        Import-Module Pester -MinimumVersion 4.4.2 
+        Install-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 -Scope CurrentUser -SkipPublisherCheck -Force
+        Import-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 
         Set-Location "./Tests"
         Invoke-Pester -Script @{Path = "./*.tests.ps1"; Parameters = @{mode=$Mode}} -OutputFile "U-PS-SP.xml" -OutputFormat NUnitXML
       pwsh: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,8 @@ steps:
     targetType: 'inline'
     script: |
       $Mode="Bearer"
-      Install-Module Pester -MinimumVersion 4.4.2 -Scope CurrentUser -SkipPublisherCheck -Force
-      Import-Module Pester -MinimumVersion 4.4.2 
+      Install-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 -Scope CurrentUser -SkipPublisherCheck -Force
+      Import-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 
       Set-Location "./Tests"
       $Edition = $PSVersionTable.PSEdition
       Invoke-Pester -Script @{Path = "./*.tests.ps1"; Parameters = @{mode=$Mode}} -OutputFile "TestResults-$Edition-$Mode.xml" -OutputFormat NUnitXML
@@ -62,8 +62,8 @@ steps:
     targetType: 'inline'
     script: |
       $Mode="ServicePrincipal"
-      Install-Module Pester -MinimumVersion 4.4.2 -Scope CurrentUser -SkipPublisherCheck -Force
-      Import-Module Pester -MinimumVersion 4.4.2 
+      Install-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 -Scope CurrentUser -SkipPublisherCheck -Force
+      Import-Module Pester -MinimumVersion 4.4.2 -MaximumVersion 4.10.1 
       Set-Location "./Tests"
       $Edition = $PSVersionTable.PSEdition
       Invoke-Pester -Script @{Path = "./*.tests.ps1"; Parameters = @{mode=$Mode}} -OutputFile "TestResults-$Edition-$Mode.xml" -OutputFormat NUnitXML


### PR DESCRIPTION
Tests need updating for Pester 5 - in the meantime set the max Pester version to 4.10.1. Annoyingly this is hard coded in lots of places. Quite a bit of tech debt to cleanup.