### PR TITLE
Change from PS cmdlets to .NET commands for handling new lines and files

### DIFF
--- a/Public/Import-DatabricksFolder.ps1
+++ b/Public/Import-DatabricksFolder.ps1
@@ -57,6 +57,9 @@ Function Import-DatabricksFolder {
                 Write-Verbose "# A 404 response is expected if the specified workspace does not exist in Databricks
                                # In this case, there will be no existing files to clean so the exception can be safely ignored"
             }
+            else{
+                Throw $_.Exception
+            }
         }
         foreach ($f in $ExistingFiles) {
             if ($f.object_type -eq "DIRECTORY") {

--- a/Public/Import-DatabricksFolder.ps1
+++ b/Public/Import-DatabricksFolder.ps1
@@ -35,7 +35,8 @@ Function Import-DatabricksFolder {
         [parameter(Mandatory = $false)][string]$Region,
         [parameter(Mandatory = $true)][string]$LocalPath,
         [parameter(Mandatory = $true)][string]$DatabricksPath,
-        [parameter(Mandatory = $false)][switch]$Clean
+        [parameter(Mandatory = $false)][switch]$Clean,
+        [parameter(Mandatory = $false)][int]$SleepInMs = 200
     )
     $threadJobs = @()
     $throttleLimit = GetCpuCount
@@ -58,13 +59,13 @@ Function Import-DatabricksFolder {
         foreach ($f in $ExistingFiles) {
             if ($f.object_type -eq "DIRECTORY") {
                 Write-Verbose "Removing directory $($f.path)"
-                Remove-DatabricksNotebook -Path $f.path -Recursive
+                Remove-DatabricksNotebook -Path $f.path -Recursive -SleepInMs $SleepInMs 
             }
             else {
                 Write-Verbose "Removing file $($f.path)"
-                Remove-DatabricksNotebook -Path $f.path 
+                Remove-DatabricksNotebook -Path $f.path -SleepInMs $SleepInMs
             }
-            Start-Sleep -Milliseconds 200 # Prevent 429 responses
+            Start-Sleep -Milliseconds $SleepInMs # Prevent 429 responses
         }
     }
     

--- a/Public/Import-DatabricksFolder.ps1
+++ b/Public/Import-DatabricksFolder.ps1
@@ -52,9 +52,11 @@ Function Import-DatabricksFolder {
         try {
             $ExistingFiles = Get-DatabricksWorkspaceFolder -Path $DatabricksPath
         }
-        catch [System.Net.WebException] {
-            # A 404 response is expected if the specified workspace does not exist in Databricks
-            # In this case, there will be no existing files to clean so the exception can be safely ignored
+        catch {
+            if ($_.Exception.Response.StatusCode -eq "NotFound") {
+                Write-Verbose "# A 404 response is expected if the specified workspace does not exist in Databricks
+                               # In this case, there will be no existing files to clean so the exception can be safely ignored"
+            }
         }
         foreach ($f in $ExistingFiles) {
             if ($f.object_type -eq "DIRECTORY") {
@@ -95,7 +97,7 @@ Function Import-DatabricksFolder {
         }
 
         # Handle empty files
-        if($BinaryContents){
+        if ($BinaryContents) {
             $EncodedContents = [System.Convert]::ToBase64String($BinaryContents)
         }
         else {

--- a/Public/Remove-DatabricksNotebook.ps1
+++ b/Public/Remove-DatabricksNotebook.ps1
@@ -31,7 +31,8 @@ Function Remove-DatabricksNotebook {
         [parameter(Mandatory = $false)][string]$BearerToken,    
         [parameter(Mandatory = $false)][string]$Region,
         [parameter(Mandatory = $true)][string]$Path,
-        [parameter(Mandatory = $false)][switch]$Recursive
+        [parameter(Mandatory = $false)][switch]$Recursive,
+        [parameter(Mandatory = $false)][int]$SleepInMs = 200
     )
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -52,7 +53,7 @@ Function Remove-DatabricksNotebook {
     catch {
         if ($_.Exception.Response.StatusCode -eq "Too Many Requests") {
             Write-Verbose "Too many requests, trying once more"
-            Start-Sleep -Milliseconds 400
+            Start-Sleep -Milliseconds $SleepInMs
             Invoke-RestMethod -Uri "$global:DatabricksURI/api/2.0/workspace/delete" -Body $BodyText -Method 'POST' -Headers $Headers
         }
     }

--- a/Public/Remove-DatabricksNotebook.ps1
+++ b/Public/Remove-DatabricksNotebook.ps1
@@ -51,7 +51,7 @@ Function Remove-DatabricksNotebook {
         Invoke-RestMethod -Uri "$global:DatabricksURI/api/2.0/workspace/delete" -Body $BodyText -Method 'POST' -Headers $Headers
     }
     catch {
-        if ($_.Exception.Response.StatusCode -eq "Too Many Requests") {
+        if ($_.Exception.Response.StatusCode -eq "TooManyRequests") {
             Write-Verbose "Too many requests, trying once more"
             Start-Sleep -Milliseconds $SleepInMs
             Invoke-RestMethod -Uri "$global:DatabricksURI/api/2.0/workspace/delete" -Body $BodyText -Method 'POST' -Headers $Headers

--- a/Tests/Export-DatabricksFolder.tests.ps1
+++ b/Tests/Export-DatabricksFolder.tests.ps1
@@ -1,5 +1,5 @@
 param(
-    [ValidateSet('Bearer','ServicePrincipal')][string]$Mode="ServicePrincipal"
+    [ValidateSet('Bearer','ServicePrincipal')][string]$Mode="Bearer"
 )
 
 Set-Location $PSScriptRoot
@@ -16,7 +16,7 @@ switch ($mode){
 }
 
 $ExportPath = "/Shared/UnitTest"
-$LocalOutputPath = "Output"
+$LocalOutputPath = "Samples\DummyNotebooks"
 New-Item -Name Output -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null
 
 Describe "Export-DatabricksFolder"{
@@ -36,7 +36,7 @@ Describe "Export-DatabricksFolder"{
         $Count | Should -BeGreaterThan 0
     }
 
-    AfterEach {
-        Remove-Item "$PSScriptRoot\Output" -Force -Recurse
-    }
+    # AfterEach {
+    #     Remove-Item "$PSScriptRoot\Output" -Force -Recurse
+    # }
 }

--- a/Tests/Import-DatabricksFolder.tests.ps1
+++ b/Tests/Import-DatabricksFolder.tests.ps1
@@ -1,16 +1,16 @@
 param(
-    [ValidateSet('Bearer','ServicePrincipal')][string]$Mode="ServicePrincipal"
+    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "ServicePrincipal"
 )
 
 Set-Location $PSScriptRoot
 Import-Module "..\azure.databricks.cicd.tools.psd1" -Force
 $Config = (Get-Content '.\config.json' | ConvertFrom-Json)
 
-switch ($mode){
-    ("Bearer"){
+switch ($mode) {
+    ("Bearer") {
         Connect-Databricks -Region $Config.Region -BearerToken $Config.BearerToken
     }
-    ("ServicePrincipal"){
+    ("ServicePrincipal") {
         Connect-Databricks -Region $Config.Region -DatabricksOrgId $Config.DatabricksOrgId -ApplicationId $Config.ApplicationId -Secret $Config.Secret -TenantId $Config.TenantId
     }
 }
@@ -23,7 +23,7 @@ $DatabricksPath = "/Shared/UnitTestImport"
 $DatabricksPathClean = "/Shared/UnitTestImportClean2"
 $DatabricksPathDoesNotAlreadyExist = "/Shared/NewPath"
 
-Describe "Import-DatabricksFolder Empty Folder"{
+Describe "Import-DatabricksFolder Empty Folder" {
 
     It "Empty Folder" {
         Import-DatabricksFolder `
@@ -32,7 +32,7 @@ Describe "Import-DatabricksFolder Empty Folder"{
     }
 }
 
-Describe "Import-DatabricksFolder"{
+Describe "Import-DatabricksFolder" {
 
     It "Simple Import" {
         Import-DatabricksFolder -LocalPath $UploadFolder  -DatabricksPath $DatabricksPath
@@ -54,5 +54,37 @@ Describe "Import-DatabricksFolder"{
         Import-DatabricksFolder -LocalPath "$CleanTestFolder\Folder1" -DatabricksPath $DatabricksPathDoesNotAlreadyExist -Clean
         $FilesAfterCleanUploadToNewFolder = Get-DatabricksWorkspaceFolder -Path $DatabricksPathDoesNotAlreadyExist
         $FilesAfterCleanUploadToNewFolder.path | Should be "$DatabricksPathDoesNotAlreadyExist/CleanTestFile1"
+    }
+
+    it "404 Error Does Not Throw" {
+        Mock "Get-DatabricksWorkspaceFolder" {
+            $errorDetails = '{"code": 1, "message": "NotFound", "more_info": "", "status": 404}'
+            $statusCode = 404
+            $response = New-Object System.Net.Http.HttpResponseMessage $statusCode
+            $exception = New-Object Microsoft.PowerShell.Commands.HttpResponseException "$statusCode ($($response.ReasonPhrase))", $response
+            $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
+            $errorID = 'WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
+            $targetObject = $null
+            $errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
+            $errorRecord.ErrorDetails = $errorDetails
+            Throw $errorRecord
+        }
+        {Import-DatabricksFolder -LocalPath "$CleanTestFolder\Folder1" -DatabricksPath $DatabricksPathDoesNotAlreadyExist -Clean} | Should Not Throw
+    }
+
+    it "429 Error Does Throw" {
+        Mock "Get-DatabricksWorkspaceFolder" {
+            $errorDetails = '{"code": 1, "message": "Too Many Requests", "more_info": "", "status": 429}'
+            $statusCode = 429
+            $response = New-Object System.Net.Http.HttpResponseMessage $statusCode
+            $exception = New-Object Microsoft.PowerShell.Commands.HttpResponseException "$statusCode ($($response.ReasonPhrase))", $response
+            $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
+            $errorID = 'WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
+            $targetObject = $null
+            $errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
+            $errorRecord.ErrorDetails = $errorDetails
+            Throw $errorRecord
+        }
+        {Import-DatabricksFolder -LocalPath "$CleanTestFolder\Folder1" -DatabricksPath $DatabricksPathDoesNotAlreadyExist -Clean} | Should Throw
     }
 }

--- a/Tests/Remove-DatabricksNotebook.tests.ps1
+++ b/Tests/Remove-DatabricksNotebook.tests.ps1
@@ -1,33 +1,74 @@
 param(
-    [ValidateSet('Bearer','ServicePrincipal')][string]$Mode="ServicePrincipal"
+    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "ServicePrincipal"
 )
 
 Set-Location $PSScriptRoot
 Import-Module "..\azure.databricks.cicd.tools.psd1" -Force
 $Config = (Get-Content '.\config.json' | ConvertFrom-Json)
 
-switch ($mode){
-    ("Bearer"){
+switch ($mode) {
+    ("Bearer") {
         Connect-Databricks -Region $Config.Region -BearerToken $Config.BearerToken
     }
-    ("ServicePrincipal"){
+    ("ServicePrincipal") {
         Connect-Databricks -Region $Config.Region -DatabricksOrgId $Config.DatabricksOrgId -ApplicationId $Config.ApplicationId -Secret $Config.Secret -TenantId $Config.TenantId
     }
 }
 
 $DatabricksPath = "/Shared/UnitTestImport"
 
-Describe "Import-DatabricksFolder"{
+Describe "Import-DatabricksFolder" {
     BeforeAll {
         Import-DatabricksFolder `
             -LocalPath 'Samples\DummyNotebooks' -DatabricksPath $DatabricksPath `
             -Verbose
     }
-    it "Delete single item"{
+    it "Delete single item" {
         Remove-DatabricksNotebook -Path '/Shared/UnitTestImport/SubFolder/File3'
     }
 
-    it "Delete Folder with Recurse"{
+    it "Delete Folder with Recurse" {
         Remove-DatabricksNotebook -Path $DatabricksPath -Recursive
+    }
+
+    it "Retries on First 429 Error" {
+        $script:MockInvokeRequestCalled = 0
+        $MockInvokeRestMethod = {
+            $script:MockInvokeRequestCalled++                                
+            if ($script:MockInvokeRequestCalled -eq 1) {
+                $errorDetails = '{"code": 1, "message": "Too Many Requests", "more_info": "", "status": 429}'
+                $statusCode = 429
+                $response = New-Object System.Net.Http.HttpResponseMessage $statusCode
+                $exception = New-Object Microsoft.PowerShell.Commands.HttpResponseException "$statusCode ($($response.ReasonPhrase))", $response
+                $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
+                $errorID = 'WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
+                $targetObject = $null
+                $errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
+                $errorRecord.ErrorDetails = $errorDetails
+                Throw $errorRecord
+            }
+            else {
+                return $true
+            }
+        }
+        Mock -CommandName Invoke-RestMethod -MockWith $MockInvokeRestMethod
+        {Remove-DatabricksNotebook -Path $DatabricksPath} | Should not Throw
+        Assert-MockCalled Invoke-RestMethod -Times $MockInvokeRequestCalled
+    }
+
+    it "Throws on Second 429 Error" {
+        Mock Invoke-RestMethod{
+            $errorDetails = '{"code": 1, "message": "Too Many Requests", "more_info": "", "status": 429}'
+            $statusCode = 429
+            $response = New-Object System.Net.Http.HttpResponseMessage $statusCode
+            $exception = New-Object Microsoft.PowerShell.Commands.HttpResponseException "$statusCode ($($response.ReasonPhrase))", $response
+            $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
+            $errorID = 'WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
+            $targetObject = $null
+            $errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
+            $errorRecord.ErrorDetails = $errorDetails
+            Throw $errorRecord
+        }
+        { Remove-DatabricksNotebook -Path $DatabricksPath } | Should Throw
     }
 }

--- a/Tests/Samples/DummyNotebooks/CleanTest/Folder2/CleanTestFile2.py
+++ b/Tests/Samples/DummyNotebooks/CleanTest/Folder2/CleanTestFile2.py
@@ -1,1 +1,4 @@
 print("CleanTestFile2")
+print('hello world')
+print("bob")
+print("test")

--- a/Tests/Samples/DummyNotebooks/File1.py
+++ b/Tests/Samples/DummyNotebooks/File1.py
@@ -1,2 +1,3 @@
-
 print('hello world')
+print("bob")
+print("test")

--- a/Tests/Samples/DummyNotebooks/File4.py
+++ b/Tests/Samples/DummyNotebooks/File4.py
@@ -1,4 +1,4 @@
-print("CleanTestFile1")
+import json
 print('hello world')
 print("bob")
 print("test")

--- a/Tests/Samples/DummyNotebooks/SubFolder/File3.py
+++ b/Tests/Samples/DummyNotebooks/SubFolder/File3.py
@@ -1,1 +1,3 @@
-print('hello')
+print('hello world')
+print("bob")
+print("test")


### PR DESCRIPTION
PowerShell cmdlets have proven to cause issues across versions of PS and different OS and Git configs. Replace with .NET cmds seems to have removed issues of line formatting. 

Have also removed the error where empty notebooks causes the threadjob to fail by checking ```NewResponse``` is not null.

Have got the error message writing to console when one of the threadjobs have failed, which wasn't the case before.

Have updated the ```Export-DatabricksFolder.tests.ps1``` to write the output to where the notebooks were initially pushed from so that we can check if the content has been altered by any of the import/export commands.

Added more notebooks with more lines for testing.
Should resolve - 
#138 

#140 

Should undo damage caused by - 

#139 