### PR TITLE
Support for Regional Differences

### DIFF
--- a/Public/Add-DatabricksMemberToGroup.ps1
+++ b/Public/Add-DatabricksMemberToGroup.ps1
@@ -56,7 +56,7 @@ Function Add-DatabricksMemberToGroup
         }
 
         Invoke-RestMethod -Method Post -Body $body -Uri "$global:DatabricksURI/api/2.0/groups/add-member" -Headers $Headers -OutFile $OutFile
-        Write-Verbose "User $UserName added to $Parent group"
+        Write-Verbose "User $Member added to $Parent group"
     }
     Catch {
         if ($_.Exception.Response -eq $null) {

--- a/Public/Connect-Databricks.ps1
+++ b/Public/Connect-Databricks.ps1
@@ -138,10 +138,10 @@ Function Connect-Databricks {
     if ($PSBoundParameters.ContainsKey('TestConnectDatabricks')) {
         Write-Verbose "Connecting to Workspace to verify connection details are correct:" 
         if ($PSCmdlet.ParameterSetName -eq "Bearer") {
-            Test-ConnectDatabricks -Region $AzureRegion -BearerToken $BearerToken | Out-Null
+            Test-ConnectDatabricks -Region $AzureRegion -BearerToken $BearerToken
         }
         else {
-            Test-ConnectDatabricks | Out-Null
+            Test-ConnectDatabricks
         }
     }
 }

--- a/Public/Connect-Databricks.ps1
+++ b/Public/Connect-Databricks.ps1
@@ -58,78 +58,80 @@
 #>
 
 Function Connect-Databricks {  
-    [cmdletbinding(DefaultParameterSetName='Bearer')]
+    [cmdletbinding(DefaultParameterSetName = 'Bearer')]
     param (
-        [parameter(Mandatory = $true, ParameterSetName='Bearer')]
+        [parameter(Mandatory = $true, ParameterSetName = 'Bearer')]
         [string]$BearerToken,
 
-        [parameter(Mandatory = $true, ParameterSetName='Bearer')]
-        [parameter(Mandatory = $true, ParameterSetName='AADwithOrgId')]
-        [parameter(Mandatory = $true, ParameterSetName='AADwithResource')]
+        [parameter(Mandatory = $true, ParameterSetName = 'Bearer')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithOrgId')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithResource')]
         [string]$Region,
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithResource')]
+        [string]$DatabricksURI = "https://$Region.azuredatabricks.net" ,
 
-        [parameter(Mandatory = $true, ParameterSetName='AADwithOrgId')]
-        [parameter(Mandatory = $true, ParameterSetName='AADwithResource')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithOrgId')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithResource')]
         [string]$ApplicationId,
-        [parameter(Mandatory = $true, ParameterSetName='AADwithOrgId')]
-        [parameter(Mandatory = $true, ParameterSetName='AADwithResource')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithOrgId')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithResource')]
         [string]$Secret,
 
-        [parameter(Mandatory = $true, ParameterSetName='AADwithOrgId')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithOrgId')]
         [string]$DatabricksOrgId,
 
-        [parameter(Mandatory = $true, ParameterSetName='AADwithOrgId')]
-        [parameter(Mandatory = $true, ParameterSetName='AADwithResource')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithOrgId')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithResource')]
         [string]$TenantId,
-        [parameter(Mandatory = $true, ParameterSetName='AADwithResource')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithResource')]
         [string]$SubscriptionId,
-        [parameter(Mandatory = $true, ParameterSetName='AADwithResource')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithResource')]
         [string]$ResourceGroupName,
-        [parameter(Mandatory = $true, ParameterSetName='AADwithResource')]
+        [parameter(Mandatory = $true, ParameterSetName = 'AADwithResource')]
         [string]$WorkspaceName,
 
-        [parameter(Mandatory = $false, ParameterSetName='AADwithOrgId')]
-        [parameter(Mandatory = $false, ParameterSetName='AADwithResource')]
+        [parameter(Mandatory = $false, ParameterSetName = 'AADwithOrgId')]
+        [parameter(Mandatory = $false, ParameterSetName = 'AADwithResource')]
         [switch]$Force
     ) 
 
     Write-Verbose "Globals at start of Connect:" 
     Write-Globals
 
-    if ($Force){
+    if ($Force) {
         Write-Verbose "-Force set - clearing global variables"
         Set-GlobalsNull
     }
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    $AzureRegion = $Region.Replace(" ","")
-    $URI = "https://login.microsoftonline.com/$tenantId/oauth2/token/"
-
-    if ($PSCmdlet.ParameterSetName -eq "Bearer"){
+    if ($PSCmdlet.ParameterSetName -eq "Bearer") {
         Set-GlobalsNull
         # Use Databricks Bearer Token Method
         $global:DatabricksAccessToken = "Bearer $BearerToken"
         # Basically do not expire the token
         $global:DatabricksTokenExpires = (Get-Date).AddDays(90)
-        $global:Headers = @{"Authorization"="$global:DatabricksAccessToken"}
+        $global:Headers = @{"Authorization" = "$global:DatabricksAccessToken" }
     }
-    elseif($PSCmdlet.ParameterSetName -eq "AADwithOrgId"){
+    elseif ($PSCmdlet.ParameterSetName -eq "AADwithOrgId") {
         Get-AADDatabricksToken
-        $global:Headers = @{"Authorization"="Bearer $DatabricksAccessToken";
-            "X-Databricks-Org-Id"="$DatabricksOrgId"
+        $global:Headers = @{"Authorization" = "Bearer $DatabricksAccessToken";
+            "X-Databricks-Org-Id"           = "$DatabricksOrgId"
         }
         $global:DatabricksOrgId = $DatabricksOrgId
     }
-    elseif($PSCmdlet.ParameterSetName -eq "AADwithResource"){
+    elseif ($PSCmdlet.ParameterSetName -eq "AADwithResource") {
+        $AzureRegion = $Region.Replace(" ", "")
+        $URI = "https://login.microsoftonline.com/$tenantId/oauth2/token/"
         Get-AADManagementToken
         Get-AADDatabricksToken
-        $global:Headers = @{"Authorization"="Bearer $global:DatabricksAccessToken";
-            "X-Databricks-Azure-SP-Management-Token"=$global:ManagementAccessToken;
-            "X-Databricks-Azure-Workspace-Resource-Id"="/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.Databricks/workspaces/$WorkspaceName"
+        $global:Headers = @{"Authorization"            = "Bearer $global:DatabricksAccessToken";
+            "X-Databricks-Azure-SP-Management-Token"   = $global:ManagementAccessToken;
+            "X-Databricks-Azure-Workspace-Resource-Id" = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.Databricks/workspaces/$WorkspaceName"
         }
+        $global:DatabricksURI = $DatabricksURI.Replace(" ", "")
     }
 
-    $global:DatabricksURI = "https://$AzureRegion.azuredatabricks.net" 
+
 
     Write-Verbose "Globals at end of Connect:" 
     Write-Globals

--- a/Public/Connect-Databricks.ps1
+++ b/Public/Connect-Databricks.ps1
@@ -131,8 +131,6 @@ Function Connect-Databricks {
         $global:DatabricksURI = $DatabricksURI.Replace(" ", "")
     }
 
-
-
     Write-Verbose "Globals at end of Connect:" 
     Write-Globals
 }

--- a/Public/Connect-Databricks.ps1
+++ b/Public/Connect-Databricks.ps1
@@ -71,6 +71,10 @@ Function Connect-Databricks {
         [parameter(Mandatory = $false, ParameterSetName = 'AADwithOrgId')]
         [parameter(Mandatory = $false, ParameterSetName = 'AADwithResource')]
         [string]$DatabricksURISuffix = "azuredatabricks.net" ,
+        [parameter(Mandatory = $false, ParameterSetName = 'Bearer')]
+        [parameter(Mandatory = $false, ParameterSetName = 'AADwithOrgId')]
+        [parameter(Mandatory = $false, ParameterSetName = 'AADwithResource')]
+        [string]$oauthLogin = "login.microsoftonline.com" ,
         [parameter(Mandatory = $true, ParameterSetName = 'AADwithOrgId')]
         [parameter(Mandatory = $true, ParameterSetName = 'AADwithResource')]
         [string]$ApplicationId,
@@ -108,7 +112,8 @@ Function Connect-Databricks {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $AzureRegion = $Region.Replace(" ", "")
     $AzureDatabricksURISuffix = $DatabricksURISuffix.Trim(".", " ").Replace(" ", "")
-    $URI = "https://login.microsoftonline.com/$tenantId/oauth2/token/"
+    $oauthLogin = $oauthLogin.Trim("/", " ").Replace(" ", "")
+    $URI = "https://$oauthLogin/$tenantId/oauth2/token/"
     if ($PSCmdlet.ParameterSetName -eq "Bearer") {
         Set-GlobalsNull
         # Use Databricks Bearer Token Method

--- a/Public/Connect-Databricks.ps1
+++ b/Public/Connect-Databricks.ps1
@@ -71,7 +71,6 @@ Function Connect-Databricks {
         [parameter(Mandatory = $false, ParameterSetName = 'AADwithOrgId')]
         [parameter(Mandatory = $false, ParameterSetName = 'AADwithResource')]
         [string]$DatabricksURISuffix = "azuredatabricks.net" ,
-        [parameter(Mandatory = $false, ParameterSetName = 'Bearer')]
         [parameter(Mandatory = $false, ParameterSetName = 'AADwithOrgId')]
         [parameter(Mandatory = $false, ParameterSetName = 'AADwithResource')]
         [string]$oauthLogin = "login.microsoftonline.com" ,
@@ -112,8 +111,8 @@ Function Connect-Databricks {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $AzureRegion = $Region.Replace(" ", "")
     $AzureDatabricksURISuffix = $DatabricksURISuffix.Trim(".", " ").Replace(" ", "")
-    $oauthLogin = $oauthLogin.Trim("/", " ").Replace(" ", "")
-    $URI = "https://$oauthLogin/$tenantId/oauth2/token/"
+    $AzureOauthLogin = $oauthLogin.Trim("/", " ").Replace(" ", "")
+    $URI = "https://$AzureOauthLogin/$tenantId/oauth2/token/"
     if ($PSCmdlet.ParameterSetName -eq "Bearer") {
         Set-GlobalsNull
         # Use Databricks Bearer Token Method

--- a/Public/Test-ConnectDatabricks.ps1
+++ b/Public/Test-ConnectDatabricks.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-Get a list of Spark versions available for use.
+Called in Connect-Databricks when switch TestConnectDatabricks is included
 
 .DESCRIPTION
-Get a list of Spark versions available for use.
+Called in Connect-Databricks when switch TestConnectDatabricks is included
 
 .PARAMETER BearerToken
 Your Databricks Bearer token to authenticate to your workspace (see User Settings in Datatbricks WebUI)
@@ -12,10 +12,10 @@ Your Databricks Bearer token to authenticate to your workspace (see User Setting
 Azure Region - must match the URL of your Databricks workspace, example northeurope
 
 .EXAMPLE
-PS C:\> Get-DatabricksSparkVersions -BearerToken $BearerToken -Region $Region
+PS C:\> Test-ConnectDatabricks -BearerToken $BearerToken -Region $Region
 
 .NOTES
-Author: Simon D'Morias / Data Thirst Ltd 
+Author: Richie Lee 
 
 #> 
 

--- a/Public/Test-ConnectDatabricks.ps1
+++ b/Public/Test-ConnectDatabricks.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Get a list of Spark versions available for use.
+
+.DESCRIPTION
+Get a list of Spark versions available for use.
+
+.PARAMETER BearerToken
+Your Databricks Bearer token to authenticate to your workspace (see User Settings in Datatbricks WebUI)
+
+.PARAMETER Region
+Azure Region - must match the URL of your Databricks workspace, example northeurope
+
+.EXAMPLE
+PS C:\> Get-DatabricksSparkVersions -BearerToken $BearerToken -Region $Region
+
+.NOTES
+Author: Simon D'Morias / Data Thirst Ltd 
+
+#> 
+
+Function Test-ConnectDatabricks { 
+    [cmdletbinding()]
+    param (
+        [parameter(Mandatory = $false)][string]$BearerToken, 
+        [parameter(Mandatory = $false)][string]$Region
+    ) 
+
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $Headers = GetHeaders $PSBoundParameters 
+    try {
+        Invoke-RestMethod -Method Get -Uri "$global:DatabricksURI/api/2.0/clusters/spark-versions" -Headers $Headers | Out-Null
+    }
+    catch {
+        Write-Error $_.Exception.Response
+        Throw
+    }
+}
+    

--- a/Tests/Connect-Databricks.tests.ps1
+++ b/Tests/Connect-Databricks.tests.ps1
@@ -10,11 +10,30 @@ Describe "ConnectFunctions"{
     }
 
     It "Legacy token connect"{
-        Connect-Databricks -BearerToken $Config.BearerToken -Region $Config.Region
+        {Connect-Databricks -BearerToken $Config.BearerToken `
+        -Region $Config.Region} | Should Not Throw
         $global:DatabricksAccessToken | Should -Not -Be $null
         $global:ManagementAccessToken | Should -Be $null
         $global:Headers | Should -Not -Be $null
     }
+
+    It "Legacy token connect testing connection"{
+        {Connect-Databricks -BearerToken $Config.BearerToken `
+        -Region $Config.Region -TestConnectDatabricks} | Should Not Throw
+        $global:DatabricksAccessToken | Should -Not -Be $null
+        $global:ManagementAccessToken | Should -Be $null
+        $global:Headers | Should -Not -Be $null
+    }
+
+
+    It "Legacy token connect testing connection with non-existent region"{
+        {Connect-Databricks -BearerToken $Config.BearerToken `
+        -Region "mars" -TestConnectDatabricks} | Should Throw
+        $global:DatabricksAccessToken | Should -Not -Be $null
+        $global:ManagementAccessToken | Should -Be $null
+        $global:Headers | Should -Not -Be $null
+    }
+
 
     It "ApplicationId AAD Autentication using OrgId"{
         Connect-Databricks -Region $Config.Region -ApplicationId $Config.ApplicationId -Secret $Config.Secret `

--- a/Tests/New-DataBricksBearerToken.tests.ps1
+++ b/Tests/New-DataBricksBearerToken.tests.ps1
@@ -29,9 +29,3 @@ Describe "New-DatabricksBearerToken" {
         Remove-DatabricksBearerToken -TokenId ($Global:Token.token_info.token_id)
     }
 }
-
-$Token = New-DatabricksBearerToken -LifetimeSeconds 180 -Comment "Test"
-
-$Token.GetType()
-
-$Token.token_value

--- a/Tests/New-DataBricksBearerToken.tests.ps1
+++ b/Tests/New-DataBricksBearerToken.tests.ps1
@@ -16,16 +16,22 @@ switch ($mode){
 }
 
 
-Describe "New-DatabricksBearerToken" {
-    It "Token with Comment"{
-        $Global:Token = New-DatabricksBearerToken -LifetimeSeconds 180 -Comment "Test"
-    }
+# Describe "New-DatabricksBearerToken" {
+#     It "Token with Comment"{
+#         $Global:Token = New-DatabricksBearerToken -LifetimeSeconds 180 -Comment "Test"
+#     }
 
-    It "Token with No Comment"{
-        $Global:Token = New-DatabricksBearerToken -LifetimeSeconds 180
-    }
+#     It "Token with No Comment"{
+#         $Global:Token = New-DatabricksBearerToken -LifetimeSeconds 180
+#     }
 
-    AfterEach{
-        Remove-DatabricksBearerToken -TokenId ($Global:Token.token_info.token_id)
-    }
-}
+#     AfterEach{
+#         Remove-DatabricksBearerToken -TokenId ($Global:Token.token_info.token_id)
+#     }
+# }
+
+$Token = New-DatabricksBearerToken -LifetimeSeconds 180 -Comment "Test"
+
+$Token.GetType()
+
+$Token.token_value

--- a/Tests/New-DataBricksBearerToken.tests.ps1
+++ b/Tests/New-DataBricksBearerToken.tests.ps1
@@ -16,19 +16,19 @@ switch ($mode){
 }
 
 
-# Describe "New-DatabricksBearerToken" {
-#     It "Token with Comment"{
-#         $Global:Token = New-DatabricksBearerToken -LifetimeSeconds 180 -Comment "Test"
-#     }
+Describe "New-DatabricksBearerToken" {
+    It "Token with Comment"{
+        $Global:Token = New-DatabricksBearerToken -LifetimeSeconds 180 -Comment "Test"
+    }
 
-#     It "Token with No Comment"{
-#         $Global:Token = New-DatabricksBearerToken -LifetimeSeconds 180
-#     }
+    It "Token with No Comment"{
+        $Global:Token = New-DatabricksBearerToken -LifetimeSeconds 180
+    }
 
-#     AfterEach{
-#         Remove-DatabricksBearerToken -TokenId ($Global:Token.token_info.token_id)
-#     }
-# }
+    AfterEach{
+        Remove-DatabricksBearerToken -TokenId ($Global:Token.token_info.token_id)
+    }
+}
 
 $Token = New-DatabricksBearerToken -LifetimeSeconds 180 -Comment "Test"
 


### PR DESCRIPTION
China Azure Databricks Workspaces have different domain [name and region and oauth endpoints](https://docs.azure.cn/zh-cn/storage/blobs/data-lake-storage-events); included optional parameters for these with default so it will continue in non-China without breaking anything.

Added optional test for ```Connect-Databricks``` to ensure connection is correct.

Minor tidying up of correct parameter names being called.