### PR TITLE
Added AzureAttributes optional parameter to New-DatabricksCluster 

### DIFF
--- a/Private/GetNewCluster.ps1
+++ b/Private/GetNewCluster.ps1
@@ -13,6 +13,7 @@ Function GetNewClusterCluster {
         [parameter(Mandatory = $false)][ValidateSet(2,3)] [string]$PythonVersion=3,
         [parameter(Mandatory = $false)][string]$ClusterLogPath,
         [parameter(Mandatory = $false)][string]$InstancePoolId,
+        [parameter(Mandatory = $false)][hashtable]$AzureAttributes,
         [parameter(Mandatory = $false)][object]$ClusterObject
 
     ) 
@@ -73,6 +74,8 @@ Function GetNewClusterCluster {
     If ($PSBoundParameters.ContainsKey('InstancePoolId') -and (!([string]::IsNullOrEmpty($InstancePoolId)))) {
         $Body['instance_pool_id'] = $InstancePoolId
     }
+
+    if ($null -ne $AzureAttributes) {$Body['azure_attributes'] = $AzureAttributes}
 
     
     

--- a/Public/New-DatabricksCluster.ps1
+++ b/Public/New-DatabricksCluster.ps1
@@ -64,6 +64,10 @@ Example dbfs:/logs/mycluster
 If you would like to use nodes from an instance pool set the pool id 
 https://docs.azuredatabricks.net/user-guide/instance-pools/index.html#instance-pools
 
+.PARAMETER AzureAttributes
+Hashtable. 
+Example @{first_on_demand=1; availability="SPOT_WITH_FALLBACK_AZURE"; spot_bid_max_price=-1}
+
 .PARAMETER InputObject
 Pipe the contents of Get-DatabricksCluster or a json file
 
@@ -93,6 +97,7 @@ Function New-DatabricksCluster {
         [parameter(Mandatory = $false)][ValidateSet(2,3)] [string]$PythonVersion=3,
         [parameter(Mandatory = $false)][string]$ClusterLogPath,
         [parameter(Mandatory = $false)][string]$InstancePoolId,
+        [parameter(Mandatory = $false)][hashtable]$AzureAttributes,
         [parameter(ValueFromPipeline)][object]$InputObject
     ) 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -153,9 +158,10 @@ Function New-DatabricksCluster {
     $ClusterArgs['PythonVersion'] = $PythonVersion
     $ClusterArgs['ClusterLogPath'] = $ClusterLogPath
     $ClusterArgs['InstancePoolId'] = $InstancePoolId
+    $ClusterArgs['AzureAttributes'] = $AzureAttributes
     $ClusterArgs['ClusterObject'] = $InputObject
-
     
+
     $Body += GetNewClusterCluster @ClusterArgs
     if ($ClusterName){
         $Body += @{"cluster_name"=$ClusterName}

--- a/Tests/GetNewCluster.tests.ps1
+++ b/Tests/GetNewCluster.tests.ps1
@@ -194,6 +194,44 @@ Describe "GetNewCluster" {
 
         }
 
+        It "Multi Value Settings with AzureAttributes"{
+                $SparkVersion="5.5.x-scala2.11"
+                $NodeType="Standard_D3_v2"
+                $MinNumberOfWorkers=1
+                $MaxNumberOfWorkers=1
+                $Spark_conf = @{"spark.speculation"=$false; "spark.streaming.ui.retainedBatches"= 5}
+                $CustomTags = @{CreatedBy="SimonDM";Tag1="HelloWorld"}
+                $InitScripts = "dbfs:/script/script1", "dbfs:/script/script2"
+                $SparkEnvVars = @{SPARK_WORKER_MEMORY="29000m";SPARK_LOCAL_DIRS="/local_disk0"}
+                $AutoTerminationMinutes = 15
+                $PythonVersion = 2
+                $AzureAttributes = @{first_on_demand=1; availability="SPOT_WITH_FALLBACK_AZURE"; spot_bid_max_price=-1}
+
+                $res = GetNewClusterCluster `
+                        -SparkVersion $SparkVersion `
+                        -NodeType $NodeType `
+                        -DriverNodeType $DriverNodeType `
+                        -MinNumberOfWorkers $MinNumberOfWorkers `
+                        -MaxNumberOfWorkers $MaxNumberOfWorkers `
+                        -AutoTerminationMinutes $AutoTerminationMinutes `
+                        -Spark_conf $Spark_conf `
+                        -CustomTags $CustomTags `
+                        -InitScripts $InitScripts `
+                        -SparkEnvVars $SparkEnvVars `
+                        -PythonVersion $PythonVersion `
+                        -AzureAttributes $AzureAttributes
+
+                $res['spark_version'] | Should -be "5.5.x-scala2.11"
+                $res['Node_type_id'] | Should -be "Standard_D3_v2"
+                $res['spark_env_vars'].Count | Should -be 2
+                $res['custom_tags'].Count | Should -be 2
+                $res['init_scripts'].Count | Should -be 2
+                $res['spark_conf'].Count | Should -be 2 -Because "spark_conf"
+                $res['init_scripts'][0].dbfs.destination | Should -be "dbfs:/script/script1" -Because "Init Scripts"
+                $res['azure_attributes'].Count | Should -be 3 -Because "azure_attributes"
+                $res['azure_attributes'].availability | Should -be "SPOT_WITH_FALLBACK_AZURE" -Because "azure_attributes"
+        }
+
         It "Pass as json"{
                 $json = '{
                         "num_workers": 1,
@@ -232,6 +270,53 @@ Describe "GetNewCluster" {
                 $res['custom_tags'].Count | Should -be 0
                 $res['init_scripts'].Count | Should -be 0
                 $res['spark_conf'].Count | Should -be 3
+        }
+
+        It "Pass as json with AzureAttributes"{
+                $json = '{
+                        "num_workers": 1,
+                        "cluster_name": "CICD",
+                        "spark_version": "6.4.x-scala2.11",
+                        "spark_conf": {
+                            "spark.databricks.service.server.enabled": "true",
+                            "spark.databricks.service.port": "8787",
+                            "spark.databricks.delta.preview.enabled": "true"
+                        },
+                        "azure_attributes": {
+                            "first_on_demand": 1,
+                            "availability": "SPOT_WITH_FALLBACK_AZURE",
+                            "spot_bid_max_price": -1
+                        },
+                        "node_type_id": "Standard_DS3_v2",
+                        "driver_node_type_id": "Standard_DS3_v2",
+                        "ssh_public_keys": [],
+                        "custom_tags": {},
+                        "cluster_log_conf": {
+                            "dbfs": {
+                                "destination": "dbfs:/cluster-logs"
+                            }
+                        },
+                        "spark_env_vars": {
+                            "LIQUIXCONFIG": "/dbfs/liquix/config.json"
+                        },
+                        "autotermination_minutes": 30,
+                        "enable_elastic_disk": true,
+                        "cluster_source": "UI",
+                        "init_scripts": [],
+                        "cluster_id": "0920-081811-lamps471"
+                    }' | ConvertFrom-Json
+
+                $res = GetNewClusterCluster `
+                        -ClusterObject $json
+                
+                $res['spark_version'] | Should -be "6.4.x-scala2.11"
+                $res['Node_type_id'] | Should -be "Standard_DS3_v2"
+                $res['spark_env_vars'].Count | Should -be 1
+                $res['custom_tags'].Count | Should -be 0
+                $res['init_scripts'].Count | Should -be 0
+                $res['spark_conf'].Count | Should -be 3
+                $res['azure_attributes'].Count | Should -be 3 -Because "azure_attributes"
+                $res['azure_attributes'].availability | Should -be "SPOT_WITH_FALLBACK_AZURE" -Because "azure_attributes"
         }
 
         It "Override as json values"{

--- a/Tests/New-DataBricksCluster.tests.ps1
+++ b/Tests/New-DataBricksCluster.tests.ps1
@@ -1,6 +1,5 @@
 param(
-    #[ValidateSet('Bearer','ServicePrincipal')][string]$Mode="ServicePrincipal"
-    [string]$Mode="Bearer"
+    [ValidateSet('Bearer','ServicePrincipal')][string]$Mode="ServicePrincipal"
 )
 
 Set-Location $PSScriptRoot

--- a/Tests/New-DataBricksCluster.tests.ps1
+++ b/Tests/New-DataBricksCluster.tests.ps1
@@ -1,12 +1,13 @@
 param(
-    [ValidateSet('Bearer','ServicePrincipal')][string]$Mode="ServicePrincipal"
+    #[ValidateSet('Bearer','ServicePrincipal')][string]$Mode="ServicePrincipal"
+    [string]$Mode="Bearer"
 )
 
 Set-Location $PSScriptRoot
 Import-Module "..\azure.databricks.cicd.tools.psd1" -Force
 $Config = (Get-Content '.\config.json' | ConvertFrom-Json)
 
-switch ($mode){
+switch ($Mode){
     ("Bearer"){
         Connect-Databricks -Region $Config.Region -BearerToken $Config.BearerToken
     }
@@ -15,8 +16,8 @@ switch ($mode){
     }
 }
 
-$ClusterName="TestCluster5"
-$SparkVersion="5.5.x-scala2.11"
+$ClusterName="TestCluster7"
+$SparkVersion="7.3.x-scala2.12"
 $NodeType="Standard_D3_v2"
 $MinNumberOfWorkers=1
 $MaxNumberOfWorkers=1
@@ -27,6 +28,7 @@ $SparkEnvVars = @{SPARK_WORKER_MEMORY="29000m"} #;SPARK_LOCAL_DIRS="/local_disk0
 $AutoTerminationMinutes = 15
 $PythonVersion = 3
 $ClusterLogPath = "dbfs:/logs/mycluster"
+$AzureAttributes = @{first_on_demand=1; availability="SPOT_WITH_FALLBACK_AZURE"; spot_bid_max_price=-1}
 
 Describe "New-DatabricksCluster" {
     It "Create basic cluster"{
@@ -34,6 +36,22 @@ Describe "New-DatabricksCluster" {
             -MinNumberOfWorkers $MinNumberOfWorkers -MaxNumberOfWorkers $MaxNumberOfWorkers `
             -Spark_conf $Spark_conf -CustomTags $CustomTags -AutoTerminationMinutes $AutoTerminationMinutes -ClusterLogPath $ClusterLogPath `
             -Verbose -SparkEnvVars $SparkEnvVars -PythonVersion $PythonVersion -InitScripts $InitScripts
+
+        $ClusterId.Length | Should -BeGreaterThan 1
+    }
+
+    AfterAll {
+        Start-Sleep -Seconds 5
+        Remove-DatabricksCluster -ClusterName $ClusterName
+    }
+}
+
+Describe "New-DatabricksCluster with AzureAttributes" {
+    It "Create basic cluster with AzureAttributes"{
+        $ClusterId = New-DatabricksCluster  -ClusterName $ClusterName -SparkVersion $SparkVersion -NodeType $NodeType `
+            -MinNumberOfWorkers $MinNumberOfWorkers -MaxNumberOfWorkers $MaxNumberOfWorkers `
+            -Spark_conf $Spark_conf -CustomTags $CustomTags -AutoTerminationMinutes $AutoTerminationMinutes -ClusterLogPath $ClusterLogPath `
+            -Verbose -SparkEnvVars $SparkEnvVars -PythonVersion $PythonVersion -InitScripts $InitScripts -AzureAttributes $AzureAttributes
 
         $ClusterId.Length | Should -BeGreaterThan 1
     }
@@ -75,7 +93,7 @@ Describe "New Cluster - via pipe"{
         $json = '{
             "num_workers": 1,
             "cluster_name": "UnitTestPipeCluster",
-            "spark_version": "6.4.x-scala2.11",
+            "spark_version": "7.3.x-scala2.12",
             "spark_conf": {
                 "spark.databricks.service.port": "8787",
                 "spark.databricks.service.server.enabled": "true",


### PR DESCRIPTION
This allows to create clusters with specific AzureAttributes, enabling among others, support for Spot Instances, and solving #166 

Tests to cover this new feature were added as well.

Updated tests' cluster version to 7.3 LTS, instead of 5.5 that might be deprecated soon.