### PR TITLE
Fix for Cluster Spot Instances: Don't remove azure_attributes on RemoveClusterMeta

### DIFF
--- a/Private/RemoveClusterMeta.ps1
+++ b/Private/RemoveClusterMeta.ps1
@@ -14,7 +14,6 @@ function RemoveClusterMeta{
     $hashtable.Remove('spark_context_id')
     $hashtable.Remove('last_state_loss_time')
     $hashtable.Remove('init_scripts_safe_mode')
-    $hashtable.Remove('azure_attributes')
     $hashtable.Remove('cluster_source')
 
     return $hashtable

--- a/Tests/New-DataBricksCluster.tests.ps1
+++ b/Tests/New-DataBricksCluster.tests.ps1
@@ -87,6 +87,32 @@ Describe "Edit Cluster New-DatabricksCluster" {
     }
 }
 
+Describe "Edit Cluster New-DatabricksCluster with AzureAttributes" {
+    BeforeAll{
+        $global:ClusterId = New-DatabricksCluster  -ClusterName $ClusterName -SparkVersion $SparkVersion -NodeType $NodeType `
+            -MinNumberOfWorkers $MinNumberOfWorkers -MaxNumberOfWorkers $MaxNumberOfWorkers `
+            -Spark_conf $Spark_conf -CustomTags $CustomTags -AutoTerminationMinutes $AutoTerminationMinutes -ClusterLogPath $ClusterLogPath `
+            -Verbose -SparkEnvVars $SparkEnvVars -PythonVersion $PythonVersion -InitScripts $InitScripts
+        Start-Sleep -Seconds 3
+        Stop-DatabricksCluster -ClusterName $ClusterName
+        Start-Sleep -Seconds 3
+    }
+
+    It "Update cluster with AzureAttributes (Spot Instances)"{
+        $ClusterIdEdited = New-DatabricksCluster -ClusterName $ClusterName -SparkVersion $SparkVersion -NodeType $NodeType `
+            -MinNumberOfWorkers $MinNumberOfWorkers -MaxNumberOfWorkers $MaxNumberOfWorkers `
+            -Spark_conf $Spark_conf -CustomTags $CustomTags -AutoTerminationMinutes $AutoTerminationMinutes -ClusterLogPath $ClusterLogPath `
+            -Verbose -SparkEnvVars $SparkEnvVars -PythonVersion $PythonVersion -InitScripts $InitScripts -AzureAttributes $AzureAttributes
+
+        $ClusterIdEdited | Should -Be $global:ClusterId
+    }
+
+    AfterAll {
+        Start-Sleep -Seconds 3
+        Remove-DatabricksCluster -ClusterName $ClusterName
+    }
+}
+
 Describe "New Cluster - via pipe"{
     It "Basic Pipe" {
         $json = '{

--- a/Tests/New-DataBricksCluster.tests.ps1
+++ b/Tests/New-DataBricksCluster.tests.ps1
@@ -27,7 +27,11 @@ $SparkEnvVars = @{SPARK_WORKER_MEMORY="29000m"} #;SPARK_LOCAL_DIRS="/local_disk0
 $AutoTerminationMinutes = 15
 $PythonVersion = 3
 $ClusterLogPath = "dbfs:/logs/mycluster"
-$AzureAttributes = @{first_on_demand=1; availability="SPOT_WITH_FALLBACK_AZURE"; spot_bid_max_price=-1}
+$AzureAttributes = @{
+    first_on_demand = 1
+    availability = "SPOT_WITH_FALLBACK_AZURE"
+    spot_bid_max_price = -1
+}
 
 Describe "New-DatabricksCluster" {
     It "Create basic cluster"{
@@ -104,7 +108,8 @@ Describe "Edit Cluster New-DatabricksCluster with AzureAttributes" {
             -Spark_conf $Spark_conf -CustomTags $CustomTags -AutoTerminationMinutes $AutoTerminationMinutes -ClusterLogPath $ClusterLogPath `
             -Verbose -SparkEnvVars $SparkEnvVars -PythonVersion $PythonVersion -InitScripts $InitScripts -AzureAttributes $AzureAttributes
 
-        $ClusterIdEdited | Should -Be $global:ClusterId
+        $EditedClusterConfig = Get-DatabricksClusters -ClusterId $ClusterIdEdited
+        $EditedClusterConfig.azure_attributes.availability | Should -Be $AzureAttributes.availability
     }
 
     AfterAll {


### PR DESCRIPTION
RemoveClusterMeta is used on New-DatabricksCluster function.

With the previous code, any Cluster re-deployment ("edit" mode) of an existing cluster is leaving the azure_attributes empty, resulting on values by default, thus disabling Spot Instances option if they were set before...

![image](https://user-images.githubusercontent.com/31488342/132247548-0006c2c2-9eb4-4948-b022-c68c9f6ee716.png)

It was bug very hard to find :S

