### PR TITLE
Adds support for Max Concurrency using the Jobs API

### DIFF
--- a/Public/Add-DatabricksNotebookJob.ps1
+++ b/Public/Add-DatabricksNotebookJob.ps1
@@ -106,6 +106,11 @@ Example "marc.mcdonald@microsoft.com,gordon.letwin@microsoft.com"
 Switch.
 if set, do not send email to recipients specified in on_failure if the run is skipped.
 
+
+.PARAMETER MaxConcurrentRuns
+Number of allowed concurrent runs of the job before databricks will skip further requests.
+
+
 .EXAMPLE
 PS C:\> Add-DatabricksNotebookJob -BearerToken $BearerToken -Region $Region -JobName "Job1" -SparkVersion "5.5.x-scala2.11" -NodeType "Standard_D3_v2" -MinNumberOfWorkers 2 -MaxNumberOfWorkers 2 -Timeout 100 -MaxRetries 3 -ScheduleCronExpression "0 15 22 ? * *" -Timezone "UTC" -NotebookPath "/Shared/Test" -NotebookParametersJson '{"key": "value", "name": "test2"}' -Libraries '{"pypi":{package:"simplejson"}}', '{"jar": "DBFS:/mylibraries/test.jar"}'
 
@@ -147,7 +152,8 @@ Function Add-DatabricksNotebookJob {
         [parameter(Mandatory = $false)][hashtable]$SparkEnvVars,
         [parameter(Mandatory = $false)][switch]$RunImmediate,
         [parameter(Mandatory = $false)][string]$ClusterLogPath,
-        [parameter(Mandatory = $false)][string]$InstancePoolId
+        [parameter(Mandatory = $false)][string]$InstancePoolId,
+        [parameter(Mandatory = $false)][int]$MaxConcurrentRuns
     ) 
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -198,6 +204,7 @@ Function Add-DatabricksNotebookJob {
 
         If ($PSBoundParameters.ContainsKey('Timeout')) { $JobBody['timeout_seconds'] = $Timeout }
         If ($PSBoundParameters.ContainsKey('MaxRetries')) { $JobBody['max_retries'] = $MaxRetries }
+        If ($PSBoundParameters.ContainsKey('MaxConcurrentRuns')) { $JobBody['max_concurrent_runs'] = $MaxConcurrentRuns }
         If ($PSBoundParameters.ContainsKey('ScheduleCronExpression')) {
             $JobBody['schedule'] = @{"quartz_cron_expression" = $ScheduleCronExpression; "timezone_id" = $Timezone }
         }

--- a/Tests/Add-DatabricksNotebookJob.tests.ps1
+++ b/Tests/Add-DatabricksNotebookJob.tests.ps1
@@ -30,12 +30,14 @@ Describe "Add-DatabricksNotebookJob" {
     $ClusterId = $Config.ClusterId
     $Libraries = '{"pypi":{package:"simplejson"}}', '{"jar": "DBFS:/mylibraries/test.jar"}'
     $Spark_conf = @{"spark.speculation" = $true; "spark.streaming.ui.retainedBatches" = 5 }
+    $MaxConcurrentRuns = 2
 
     It "Autoscale with parameters, new cluster" {
         $global:JobId2 = Add-DatabricksNotebookJob -JobName $JobName `
             -SparkVersion $SparkVersion -NodeType $NodeType `
             -MinNumberOfWorkers $MinNumberOfWorkers -MaxNumberOfWorkers $MaxNumberOfWorkers `
             -Timeout $Timeout -MaxRetries $MaxRetries `
+            -MaxConcurrentRuns $MaxConcurrentRuns `
             -ScheduleCronExpression $ScheduleCronExpression `
             -Timezone $Timezone -NotebookPath $NotebookPath `
             -NotebookParametersJson $NotebookParametersJson `
@@ -47,6 +49,7 @@ Describe "Add-DatabricksNotebookJob" {
     It "Update Job to use existing cluster" {
         $global:JobId1 = Add-DatabricksNotebookJob -JobName $JobName `
             -Timeout $Timeout -MaxRetries $MaxRetries `
+            -MaxConcurrentRuns $MaxConcurrentRuns `
             -ScheduleCronExpression $ScheduleCronExpression `
             -Timezone $Timezone -NotebookPath $NotebookPath `
             -NotebookParametersJson $NotebookParametersJson -ClusterId $ClusterId `
@@ -58,6 +61,7 @@ Describe "Add-DatabricksNotebookJob" {
     It "With run now" {
         $global:JobId = Add-DatabricksNotebookJob -JobName $JobName `
             -Timeout $Timeout -MaxRetries $MaxRetries `
+            -MaxConcurrentRuns $MaxConcurrentRuns `
             -Timezone $Timezone -NotebookPath $NotebookPath `
             -ClusterId $ClusterId `
             -NotebookParametersJson $NotebookParametersJson `


### PR DESCRIPTION
Adds support for the max_concurrent_runs parameter specified in the jobs API for creating a new job.
This affects the 3 functions that utilize the api:
- Add-DatabricksPythonJob
- Add-DatabricksNotebookJob
- Add-DatabricksJarJob

I have also updated the tests so that this parameter is passed to the function during testing.