### PR TITLE
Fix KeyVault backed Scope Bug when AKV has uppercase characters

### DIFF
--- a/Public/Add-DatabricksSecretScope.ps1
+++ b/Public/Add-DatabricksSecretScope.ps1
@@ -59,7 +59,7 @@ Function Add-DatabricksSecretScope
     if ($PSBoundParameters.ContainsKey('KeyVaultResourceId')){
         $kv = @{}
         $kv['resource_id'] = $KeyVaultResourceId
-        $LastPart = $KeyVaultResourceId.split('/')[-1]
+        $LastPart = ($KeyVaultResourceId.split('/')[-1]).toLower()
         $kv['dns_name'] = "https://$LastPart.vault.azure.net/"
         
         $body['scope_backend_type'] = 'AZURE_KEYVAULT'


### PR DESCRIPTION
KeyVault DNS are always lowercase and are case sensitive. When you have a KeyVault named with any uppercase characters this operation will fail saying that the KeyVault DNS doesn't exist. making the $LastPart variable lowercase fixes this bug.