### PR TITLE
add FailOnNotExist switch if attempt to remove secret/scope that does not exist

### DIFF
--- a/Public/Remove-DatabricksSecret.ps1
+++ b/Public/Remove-DatabricksSecret.ps1
@@ -17,6 +17,9 @@ Name for the scope - do not include spaces or special characters.
 .PARAMETER SecretName
 Name of the Secret to delete
 
+.PARAMETER FailOnNotExist
+Switch that if included will fail if secret does not exist
+
 .EXAMPLE 
 C:\PS> Remove-DatabricksSecret -BearerToken $BearerToken -Region $Region -ScopeName "Test1" -SecretName "Test"
 
@@ -34,7 +37,8 @@ Function Remove-DatabricksSecret
         [parameter(Mandatory=$false)][string]$BearerToken,
         [parameter(Mandatory=$false)][string]$Region,
         [parameter(Mandatory=$true)][string]$ScopeName,
-        [parameter(Mandatory=$true)][string]$SecretName
+        [parameter(Mandatory=$true)][string]$SecretName,
+        [parameter(Mandatory=$false)][switch]$FailOnNotExist
     )
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -57,6 +61,10 @@ Function Remove-DatabricksSecret
         if ($err.Contains('exist'))
         {
             Write-Verbose $err
+            if ($PSBoundParameters.ContainsKey('FailOnNotExist') -eq $true)
+            {
+                throw
+            }
         }
         else
         {

--- a/Public/Remove-DatabricksSecretScope.ps1
+++ b/Public/Remove-DatabricksSecretScope.ps1
@@ -17,6 +17,9 @@ Name of the scope to remove, will not error if it does not exist
 .PARAMETER RemoveEmptyOnly
 Switch that if included will check if scope is not empty.
 
+.PARAMETER FailOnNotExist
+Switch that if included will fail if scope does not exist
+
 .EXAMPLE
 PS C:\> Remove-DatabricksSecretScope -BearerToken $BearerToken -Region $Region -ScopeName "MyScope"
 
@@ -32,7 +35,8 @@ Function Remove-DatabricksSecretScope {
         [parameter(Mandatory = $false)][string]$BearerToken, 
         [parameter(Mandatory = $false)][string]$Region,
         [parameter(Mandatory = $true)][string]$ScopeName,
-        [parameter(Mandatory = $false)][switch]$RemoveEmptyOnly
+        [parameter(Mandatory = $false)][switch]$RemoveEmptyOnly,
+        [parameter(Mandatory = $false)][switch]$FailOnNotExist
 
     ) 
     $secrets = Get-DatabricksSecretByScope -BearerToken $BearerToken -Region $Region -ScopeName $ScopeName
@@ -61,6 +65,10 @@ Function Remove-DatabricksSecretScope {
         $err = $_.ErrorDetails.Message
         if ($err.Contains('RESOURCE_DOES_NOT_EXIST')) {
             Write-Verbose $err
+            if ($PSBoundParameters.ContainsKey('FailOnNotExist') -eq $true)
+            {
+                throw
+            }
         }
         else {
             Write-Output "StatusCode:" $_.Exception.Response.StatusCode.value__ 

--- a/Tests/Remove-DatabricksSecret.tests.ps1
+++ b/Tests/Remove-DatabricksSecret.tests.ps1
@@ -6,7 +6,7 @@ Set-Location $PSScriptRoot
 Import-Module "..\azure.databricks.cicd.tools.psd1" -Force
 $Config = (Get-Content '.\config.json' | ConvertFrom-Json)
 
-switch ($mode){
+switch ($Mode){
     ("Bearer"){
         Connect-Databricks -Region $Config.Region -BearerToken $Config.BearerToken
     }
@@ -21,10 +21,24 @@ $SecretValue = "mykey"
 
 
 Describe "Set-DatabricksSecret" {
-    BeforeAll{
+    BeforeEach{
         Set-DatabricksSecret -ScopeName $ScopeName -SecretName $SecretName -SecretValue $SecretValue  -Verbose
     }
     It "Simple test value" {
         Remove-DatabricksSecret -ScopeName $ScopeName -SecretName $SecretName -Verbose
+    }
+    
+    It "Include switch to fail if not exist" {
+        { Remove-DatabricksSecret -ScopeName $ScopeName -SecretName $SecretName -Verbose -FailOnNotExist } | Should Not Throw
+    }
+}
+
+Describe "Remove_secRetThatDoesNotExist" {
+    It "Does not throw if secret does not exist" {
+        { Remove-DatabricksSecret -ScopeName $ScopeName -SecretName $SecretName -Verbose } |Should Not Throw
+    }
+
+    It "Does throw if secret does not exist" {
+        {Remove-DatabricksSecret -ScopeName $ScopeName -SecretName $SecretName -Verbose -FailOnNotExist} | Should Throw
     }
 }

--- a/Tests/Remove-DatabricksSecretScope.tests.ps1
+++ b/Tests/Remove-DatabricksSecretScope.tests.ps1
@@ -1,5 +1,5 @@
 param(
-    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "ServicePrincipal"
+    [ValidateSet('Bearer', 'ServicePrincipal')][string]$Mode = "Bearer"
 )
 
 Set-Location $PSScriptRoot
@@ -31,12 +31,27 @@ Describe "Remove-DatabricksSecretScope" {
         }
 
     }
+
     Context "Remove an empty Secret Scope." {
-        BeforeAll {
+        BeforeEach {
             Add-DatabricksSecretScope -ScopeName $ScopeName  -Verbose
         }
         It "Remove Empty Only does not fail" {
             Remove-DatabricksSecretScope -ScopeName $ScopeName -RemoveEmptyOnly -Verbose
+        }
+        It "Remove Empty Only does not fail if FailOnNotExist included" {
+            { Remove-DatabricksSecretScope -ScopeName $ScopeName -RemoveEmptyOnly -Verbose -FailOnNotExist } | Should Not Throw
+        }
+    }
+
+    Context "Remove Secret Scope" {
+        It "Remove Empty Only does not fail if FailNotExist included" {
+            { 
+                Add-DatabricksSecretScope -ScopeName $ScopeName  -Verbose
+                Remove-DatabricksSecretScope -ScopeName $ScopeName -RemoveEmptyOnly -Verbose -FailOnNotExist } | Should Not Throw
+        }
+        It "Remove Scope does throw if FailOnNotExist included and scope does not exist" {
+            { Remove-DatabricksSecretScope -ScopeName $ScopeName -RemoveEmptyOnly -Verbose -FailOnNotExist } | Should Throw
         }
     }
 


### PR DESCRIPTION
Occasionally useful to fail if a secret/scope does not exist, so added switch to fail if this is the case.