### PR TITLE
Adding capability to upload hidden files to DBFS (#199)

### DIFF
--- a/Public/Add-DatabricksDBFSFile.ps1
+++ b/Public/Add-DatabricksDBFSFile.ps1
@@ -16,7 +16,7 @@
 
 .PARAMETER LocalRootFolder
     Path to file(s) to upload, can be relative or full. Note that subfolders are recursed always.
-    
+
 .PARAMETER FilePattern
     File pattern to match. Examples: *.py  *.*  ProjectA*.*
 
@@ -24,12 +24,12 @@
     Target folder in DBFS should start /.
     Does not need to exist.
 
-.EXAMPLE 
+.EXAMPLE
     C:\PS> Add-DatabricksDBFSFile -BearerToken $BearerToken -Region $Region -LocalRootFolder "Samples" -FilePattern "Test.jar"  -TargetLocation '/test' -Verbose
-        
+
     This example uploads a single file called Test.jar which is a relative path to your working directory.
 
-.EXAMPLE 
+.EXAMPLE
     C:\PS> Add-DatabricksDBFSFile -BearerToken $BearerToken -Region $Region -LocalRootFolder Samples/DummyNotebooks -FilePattern "*.py"  -TargetLocation '/test2/' -Verbose
 
     This example uploads a folder of py files
@@ -39,27 +39,27 @@
 
 #>
 
-Function Add-DatabricksDBFSFile {  
+Function Add-DatabricksDBFSFile {
     [cmdletbinding()]
     param (
-        [parameter(Mandatory = $false)][string]$BearerToken,    
+        [parameter(Mandatory = $false)][string]$BearerToken,
         [parameter(Mandatory = $false)][string]$Region,
         [parameter(Mandatory = $true)][string]$LocalRootFolder,
         [parameter(Mandatory = $true)][string]$FilePattern,
         [parameter(Mandatory = $true)][string]$TargetLocation
-    ) 
+    )
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    
+
     $Headers = GetHeaders $PSBoundParameters
-    
+
     $size = 1200000
     $LocalRootFolder = Resolve-Path $LocalRootFolder
     Write-Verbose $LocalRootFolder
     Push-Location
     Set-Location $LocalRootFolder
 
-    $AllFiles = Get-ChildItem -Filter $FilePattern -Recurse -File
+    $AllFiles = Get-ChildItem -Filter $FilePattern -Recurse -File -Force
 
     Foreach ($f in $AllFiles){
         $f = Resolve-Path $f.FullName
@@ -69,7 +69,7 @@ Function Add-DatabricksDBFSFile {
 
         Write-Verbose "TargetLocation: $TargetLocation"
         $FileTarget = (Join-Path $TargetLocation (Resolve-Path $f -Relative))
-        
+
         $FileTarget = $FileTarget.Replace("\","/")
         $FileTarget = $FileTarget.Replace("/./","/")
 
@@ -91,7 +91,7 @@ Function Add-DatabricksDBFSFile {
                 Write-Verbose "Uploaded $i bytes"
             }
             $part = $EncodedContents.Substring($i)
-            Add-DatabricksChunk -part $part -handle $handle.handle   
+            Add-DatabricksChunk -part $part -handle $handle.handle
 
             $Body = @{"handle"= $handle.handle}
             $BodyText = $Body | ConvertTo-Json -Depth 10
@@ -101,7 +101,7 @@ Function Add-DatabricksDBFSFile {
         {
             $Body = @{"contents"=$EncodedContents}
             $Body['path'] = $FileTarget
-            $Body['overwrite'] = "true"    
+            $Body['overwrite'] = "true"
             $BodyText = $Body | ConvertTo-Json -Depth 10
             Write-Verbose "Pushing file $($f.Path) to $FileTarget"
             Invoke-RestMethod -Uri "$global:DatabricksURI/api/2.0/dbfs/put" -Body $BodyText -Method 'POST' -Headers $Headers


### PR DESCRIPTION
By default in Windows Powershell (Powershell v5.x), the 'Get-ChildItem' command returns all files, including hidden ones.
When moving to Powershell Core (Powershell v7.x), the 'Get-ChildItem' only returns standard files, and not hidden files anymore. To also show hidden files you need to add the '-Force' switch (there's a '-Hidden' switch, but this will only show hidden files, which is not the way to go).