### PR TITLE
Set token expiry time as local time, in line with DatabricksTokenState in ConnectFunctions.ps1

### DIFF
--- a/Public/Connect-Databricks.ps1
+++ b/Public/Connect-Databricks.ps1
@@ -146,7 +146,7 @@ Function Connect-Databricks {
     elseif ($PSCmdlet.ParameterSetName -eq "AzContext") {
         $ADResponseToken = Get-AzAccessToken -ResourceUrl "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d"
         $global:DatabricksAccessToken = $ADResponseToken.Token
-        $global:DatabricksTokenExpires = ($ADResponseToken.ExpiresOn).dateTime
+        $global:DatabricksTokenExpires = ($ADResponseToken.ExpiresOn).LocalDateTime
         $global:Headers = @{"Authorization" = "Bearer $DatabricksAccessToken";
             "X-Databricks-Org-Id"           = "$DatabricksOrgId"
         }


### PR DESCRIPTION
Calling Connect-Databricks with `-AzContext` causes the `DatabricksTokenExpires` global variable to be set as UTC time.  The `DatabricksTokenState` function in ConnectFunctions.ps1 uses local time, which means it considers a just-created token which lasts for one hour to be "Expired" immediately.

I can see that, at one point, a [change](https://github.com/DataThirstLtd/azure.databricks.cicd.tools/commit/02449cbf9b68e683d2cba0f44aa9097465cbb22f) was made to use UTC time and then [reverted](https://github.com/DataThirstLtd/azure.databricks.cicd.tools/commit/65d8b3b5daa9a2c3336bcb737e077a1dd8d999b9) on the same day.

This change aligns the token expiry time.