### PR TITLE
Fixed bug in Get-DatabricksDBFSFile.ps1

### DIFF
--- a/Public/Get-DatabricksDBFSFile.ps1
+++ b/Public/Get-DatabricksDBFSFile.ps1
@@ -57,7 +57,7 @@ Function Get-DatabricksDBFSFile {
 
         $finalFile += [Convert]::FromBase64String($chunk.data)
 
-        $chunkStart = $chunkEnd + 1
+        $chunkStart = $chunkEnd
         $chunkEnd = $chunkStart + $size
         $bytesRead = $chunk.bytes_read
     }


### PR DESCRIPTION
Fixed bug where files greater than $size would have a hash that does not match hash of original file added with Add-DatabricksDBFSFile.