### PR TITLE
Fixed bug in Get-DatabricksDBFSFile.ps1

### DIFF
--- a/Public/Get-DatabricksDBFSFile.ps1
+++ b/Public/Get-DatabricksDBFSFile.ps1
@@ -53,7 +53,7 @@ Function Get-DatabricksDBFSFile {
         else {
             $BodyText = $Body | ConvertTo-Json -Depth 10
         }
-        $chunk = Invoke-RestMethod -Uri "$global:DatabricksURI/api/2.0/dbfs/read" -Body $BodyText -Method 'GET' -Headers $Headers
+        $chunk = Invoke-RestMethod -Uri "$global:DatabricksURI/api/2.0/dbfs/read" -Body $BodyText -Method 'GET' -Headers $Headers -ContentType "application/json"
 
         $finalFile += [Convert]::FromBase64String($chunk.data)
 


### PR DESCRIPTION
Fixed bug when used in PowerShell 7.4.0, line 60 would throw "The given key 'Content-Type' was not present in the dictionary."