### PR TITLE
Updated to support AUTO format in latest Databricks API

### DIFF
--- a/Public/Import-DatabricksFolder.ps1
+++ b/Public/Import-DatabricksFolder.ps1
@@ -114,8 +114,9 @@ Function Import-DatabricksFolder {
         $Body['overwrite'] = "true"
         switch ($FileToPush.Extension) {
             ".py" {
-                $Body['format'] = "SOURCE"
-                $Body['language'] = "PYTHON"
+                $Body['format'] = "AUTO"
+                $TargetPath = $Path + '/' + $FileToPush.Name
+                $Body['path'] = $TargetPath
             }
 
             ".scala" {


### PR DESCRIPTION
Updated to support AUTO format in latest Databricks API. ".py" files can now be a python file or a notebook, depending on the content of the first line. AUTO format indicates to REST API to figure out which format the files is.